### PR TITLE
Add rounding helper and tests

### DIFF
--- a/schedule_app/__init__.py
+++ b/schedule_app/__init__.py
@@ -1,7 +1,24 @@
-from flask import Flask, jsonify, render_template   # ← ここを追加
+"""Minimal Flask application factory.
 
-def create_app() -> Flask:
-    """Flask アプリを生成して返すファクトリ関数（最小構成）"""
+This module avoids importing Flask at module import time when the package is
+used purely for utilities (e.g. during unit tests).  The heavy import occurs
+only inside :func:`create_app`.
+"""
+
+from __future__ import annotations
+
+try:  # Flask may be absent in some test environments
+    from flask import Flask  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    Flask = None  # type: ignore
+
+def create_app() -> Flask:  # type: ignore[name-defined]
+    """Return a minimal Flask application."""
+    if Flask is None:  # pragma: no cover - import guard for tests
+        raise RuntimeError("Flask is required to create the application")
+
+    from flask import jsonify, render_template
+
     app = Flask(__name__)
 
     # ヘルスチェック用エンドポイント
@@ -18,4 +35,7 @@ def create_app() -> Flask:
 
 
 # `flask --app schedule_app run` で自動検出されるエントリ
-app = create_app()
+if Flask is not None:  # pragma: no cover - optional in test env
+    app = create_app()
+else:  # keep a stub for type checkers
+    app = None  # type: ignore

--- a/schedule_app/services/rounding.py
+++ b/schedule_app/services/rounding.py
@@ -1,0 +1,17 @@
+"""Time-rounding helpers (10-minute quantum)"""
+from __future__ import annotations
+
+import math
+from datetime import datetime
+
+SLOT_SEC = 600  # 10 minutes
+
+
+def quantize(dt: datetime, *, up: bool) -> datetime:  # pragma: no cover
+    """Round *dt* to the nearest 10-minute boundary.
+
+    *up* == False → floor / *up* == True → ceil
+    All calculations are done in UTC seconds since epoch."""
+    ts = dt.timestamp()
+    rounded = (math.ceil(ts / SLOT_SEC) if up else math.floor(ts / SLOT_SEC)) * SLOT_SEC
+    return datetime.utcfromtimestamp(rounded)

--- a/tests/unit/test_rounding.py
+++ b/tests/unit/test_rounding.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from schedule_app.services.rounding import quantize
+
+@pytest.mark.parametrize("iso,up,expected", [
+    ("2025-01-01T00:05:00Z", False, "2025-01-01T00:00:00Z"),
+    ("2025-01-01T00:05:00Z", True, "2025-01-01T00:10:00Z"),
+    ("2025-01-01T00:00:00Z", True, "2025-01-01T00:00:00Z"),
+])
+def test_quantize(iso: str, up: bool, expected: str):
+    dt = datetime.fromisoformat(iso.replace("Z", "+00:00")).replace(tzinfo=None)
+    want = datetime.fromisoformat(expected.replace("Z", "+00:00")).replace(tzinfo=None)
+    assert quantize(dt, up=up) == want


### PR DESCRIPTION
## Summary
- implement `quantize` time rounding utility
- allow importing package without Flask installed
- add unit test for new helper

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e3e9c8228832d91bc27965f0e13a9