### PR TITLE
Update rounding to return timezone-aware datetimes

### DIFF
--- a/schedule_app/services/rounding.py
+++ b/schedule_app/services/rounding.py
@@ -1,17 +1,40 @@
-"""Time-rounding helpers (10-minute quantum)"""
+"""Time-rounding helpers (10-minute quantum)."""
+
 from __future__ import annotations
 
 import math
-from datetime import datetime
+from datetime import datetime, timezone
 
 SLOT_SEC = 600  # 10 minutes
 
 
-def quantize(dt: datetime, *, up: bool) -> datetime:  # pragma: no cover
+def _to_utc(dt: datetime) -> datetime:
+    """Return *dt* as a timezone-aware UTC datetime.
+
+    *   naive ⇒ UTC と見なす（仕様書 §9「内部: UTC 固定」）
+    *   TZ 付き ⇒ UTC に変換
+    """
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def quantize(dt: datetime, *, up: bool) -> datetime:
     """Round *dt* to the nearest 10-minute boundary.
 
-    *up* == False → floor / *up* == True → ceil
-    All calculations are done in UTC seconds since epoch."""
-    ts = dt.timestamp()
+    Parameters
+    ----------
+    dt : datetime
+        UTC or naive (treated as UTC).
+    up : bool
+        False ⇒ floor, True ⇒ ceil.
+
+    Returns
+    -------
+    datetime
+        UTC, **timezone-aware**.
+    """
+    dt_utc = _to_utc(dt)
+    ts = dt_utc.timestamp()
     rounded = (math.ceil(ts / SLOT_SEC) if up else math.floor(ts / SLOT_SEC)) * SLOT_SEC
-    return datetime.utcfromtimestamp(rounded)
+    return datetime.fromtimestamp(rounded, timezone.utc)

--- a/tests/unit/test_rounding.py
+++ b/tests/unit/test_rounding.py
@@ -10,12 +10,15 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from schedule_app.services.rounding import quantize
 
-@pytest.mark.parametrize("iso,up,expected", [
-    ("2025-01-01T00:05:00Z", False, "2025-01-01T00:00:00Z"),
-    ("2025-01-01T00:05:00Z", True, "2025-01-01T00:10:00Z"),
-    ("2025-01-01T00:00:00Z", True, "2025-01-01T00:00:00Z"),
-])
-def test_quantize(iso: str, up: bool, expected: str):
+@pytest.mark.parametrize(
+    "iso,up,expected",
+    [
+        ("2025-01-01T00:05:00Z", False, "2025-01-01T00:00:00Z"),
+        ("2025-01-01T00:05:00Z", True, "2025-01-01T00:10:00Z"),
+        ("2025-01-01T00:00:00Z", True, "2025-01-01T00:00:00Z"),
+    ],
+)
+def test_quantize(iso: str, up: bool, expected: str) -> None:
     dt = datetime.fromisoformat(iso.replace("Z", "+00:00")).replace(tzinfo=None)
-    want = datetime.fromisoformat(expected.replace("Z", "+00:00")).replace(tzinfo=None)
+    want = datetime.fromisoformat(expected.replace("Z", "+00:00"))
     assert quantize(dt, up=up) == want


### PR DESCRIPTION
## Summary
- replace the rounding helper to work with timezone-aware datetimes
- adjust unit test expectations

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e81ccc238832db902422f1c956b12