### PR TITLE
Add GoogleClient stub

### DIFF
--- a/schedule_app/services/google_client.py
+++ b/schedule_app/services/google_client.py
@@ -1,0 +1,26 @@
+"""Google API client stub for future implementation.
+
+This module defines a minimal :class:`GoogleClient` with placeholders for
+accessing Google Calendar and Google Sheets. Actual API integration will be
+added later.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class GoogleClient:
+    """Lightweight wrapper around Google service clients."""
+
+    def __init__(self, credentials: Any) -> None:
+        """Initialize the client with OAuth2 *credentials*."""
+        self.credentials = credentials
+
+    def calendar_service(self) -> Any:
+        """Return a Google Calendar service client (stub)."""
+        raise NotImplementedError
+
+    def sheets_service(self) -> Any:
+        """Return a Google Sheets service client (stub)."""
+        raise NotImplementedError


### PR DESCRIPTION
## Summary
- define stub GoogleClient class with placeholders for Calendar and Sheets access

## Testing
- `ruff check schedule_app/services/google_client.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e86220b14832d908d5ff63f572762