### PR TITLE
Implement OAuth login flow and add tests

### DIFF
--- a/schedule_app/__init__.py
+++ b/schedule_app/__init__.py
@@ -7,6 +7,14 @@ only inside :func:`create_app`.
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import os
+import secrets
+import urllib.parse
+from datetime import datetime, timedelta
+from typing import Any
+
 try:  # Flask may be absent in some test environments
     from flask import Flask  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
@@ -17,9 +25,28 @@ def create_app() -> Flask:  # type: ignore[name-defined]
     if Flask is None:  # pragma: no cover - import guard for tests
         raise RuntimeError("Flask is required to create the application")
 
-    from flask import jsonify, render_template
+    from flask import (
+        abort,
+        jsonify,
+        redirect,
+        render_template,
+        request,
+        session,
+        url_for,
+    )
+
+    import requests
+
+    from .services.google_client import SCOPES
 
     app = Flask(__name__)
+
+    # Use a secret key from the environment for session management.  Tests
+    # may provide a fallback value.
+    app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET", "dev-secret")
+
+    TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
+    AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
 
     # ヘルスチェック用エンドポイント
     @app.get("/api/health")
@@ -30,6 +57,61 @@ def create_app() -> Flask:  # type: ignore[name-defined]
     @app.get("/")
     def index():
         return render_template("index.html")
+
+    @app.get("/login")
+    def login() -> Any:
+        """Start OAuth2 login with Google using PKCE."""
+        state = secrets.token_urlsafe(16)
+        verifier = secrets.token_urlsafe(64)
+        challenge = (
+            base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+            .rstrip(b"=")
+            .decode()
+        )
+
+        session["oauth_state"] = state
+        session["code_verifier"] = verifier
+
+        params = dict(
+            response_type="code",
+            client_id=os.environ.get("GOOGLE_CLIENT_ID", ""),
+            redirect_uri=os.environ.get("GOOGLE_REDIRECT_URI", ""),
+            scope=" ".join(SCOPES),
+            state=state,
+            code_challenge=challenge,
+            code_challenge_method="S256",
+            access_type="offline",
+            prompt="consent",
+        )
+        return redirect(f"{AUTH_ENDPOINT}?{urllib.parse.urlencode(params)}")
+
+    @app.get("/oauth2callback")
+    def oauth2callback() -> Any:
+        """Exchange authorization code for tokens."""
+        if request.args.get("state") != session.get("oauth_state"):
+            abort(400, description="state mismatch")
+
+        data = dict(
+            grant_type="authorization_code",
+            code=request.args["code"],
+            client_id=os.environ.get("GOOGLE_CLIENT_ID", ""),
+            redirect_uri=os.environ.get("GOOGLE_REDIRECT_URI", ""),
+            code_verifier=session.get("code_verifier"),
+        )
+
+        resp = requests.post(TOKEN_ENDPOINT, data=data, timeout=10)
+        if resp.status_code != 200:
+            abort(502, description="token exchange failed")
+
+        creds = resp.json()
+        session["credentials"] = {
+            "access_token": creds["access_token"],
+            "refresh_token": creds.get("refresh_token"),
+            "expires_at": (
+                datetime.utcnow() + timedelta(seconds=creds["expires_in"])
+            ).isoformat(),
+        }
+        return redirect(url_for("index"))
 
     return app
 

--- a/schedule_app/services/google_client.py
+++ b/schedule_app/services/google_client.py
@@ -9,6 +9,18 @@ from __future__ import annotations
 
 from typing import Any
 
+# OAuth scopes required for the application
+# openid, profile and email allow user authentication,
+# Calendar and Sheets readonly scopes provide read access
+# to the user's calendar and spreadsheet data.
+SCOPES = [
+    "openid",
+    "profile",
+    "email",
+    "https://www.googleapis.com/auth/calendar.readonly",
+    "https://www.googleapis.com/auth/spreadsheets.readonly",
+]
+
 
 class GoogleClient:
     """Lightweight wrapper around Google service clients."""

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1,0 +1,71 @@
+import os
+from pathlib import Path
+import sys
+
+import pytest
+
+pytest.importorskip("flask")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from schedule_app import create_app
+
+GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
+
+
+def _make_app():
+    os.environ.setdefault("FLASK_SECRET", "test-secret")
+    os.environ.setdefault("GOOGLE_CLIENT_ID", "client-id")
+    os.environ.setdefault("GOOGLE_REDIRECT_URI", "http://localhost:5173/oauth2callback")
+    return create_app()
+
+
+def test_login_redirect_and_session():
+    app = _make_app()
+    with app.test_client() as client:
+        resp = client.get("/login")
+        assert resp.status_code == 302
+        assert "accounts.google.com" in resp.headers["Location"]
+        with client.session_transaction() as sess:
+            assert "code_verifier" in sess
+            assert "oauth_state" in sess
+
+
+def test_callback_exchanges_token_and_redirects(monkeypatch):
+    app = _make_app()
+
+    def fake_post(url, data=None, timeout=None):
+        fake_post.called = True
+        fake_post.url = url
+        fake_post.data = data
+
+        class Resp:
+            status_code = 200
+
+            @staticmethod
+            def json():
+                return {
+                    "access_token": "a",
+                    "refresh_token": "r",
+                    "expires_in": 3600,
+                }
+
+        return Resp()
+
+    monkeypatch.setattr("schedule_app.__init__.requests.post", fake_post)
+
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["oauth_state"] = "abc"
+            sess["code_verifier"] = "ver"
+        resp = client.get("/oauth2callback?state=abc&code=code")
+        assert resp.status_code == 302
+        assert resp.headers["Location"] == "/"
+        with client.session_transaction() as sess:
+            creds = sess.get("credentials")
+            assert creds
+            assert creds["access_token"] == "a"
+            assert creds["refresh_token"] == "r"
+    assert fake_post.called
+    assert fake_post.url == GOOGLE_TOKEN_ENDPOINT
+

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1,14 +1,14 @@
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 import pytest
 
 pytest.importorskip("flask")
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-
-from schedule_app import create_app
+from schedule_app import create_app  # noqa: E402
 
 GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
 


### PR DESCRIPTION
## Summary
- define Google OAuth scopes in `google_client`
- implement `/login` and `/oauth2callback` routes with PKCE flow
- add integration tests for the OAuth flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e90a3f59c832da908a498dffc266a