### PR TITLE
Update OAuth callback status code

### DIFF
--- a/tests/unit/test_oauth2callback.py
+++ b/tests/unit/test_oauth2callback.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from pathlib import Path
+import sys
+
+import pytest
+
+# Make package importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from schedule_app import create_app  # noqa: E402
+
+
+def test_oauth2callback_returns_422(monkeypatch: pytest.MonkeyPatch) -> None:
+    app = create_app()
+    client = app.test_client()
+
+    def fake_exchange(code: str) -> SimpleNamespace:
+        return SimpleNamespace(status_code=500)
+
+    monkeypatch.setattr(
+        "schedule_app.__init__._exchange_code_for_token",
+        fake_exchange,
+    )
+
+    resp = client.get("/oauth2callback?code=abc")
+    assert resp.status_code == 422
+    json_data = resp.get_json()
+    assert json_data["title"] == "token exchange failed"
+    assert json_data["status"] == 422


### PR DESCRIPTION
## Summary
- add OAuth callback stub with Problem Details
- return HTTP 422 when token exchange fails
- test status code for failing token exchange

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685e93adc698832d9f3f91aae9fcfcfb