### PR TITLE
Add OAuth scopes constant

### DIFF
--- a/schedule_app/services/google_client.py
+++ b/schedule_app/services/google_client.py
@@ -9,6 +9,15 @@ from __future__ import annotations
 
 from typing import Any
 
+# OAuth scopes required for this application
+SCOPES = [
+    "openid",
+    "profile",
+    "email",
+    "https://www.googleapis.com/auth/calendar.readonly",
+    "https://www.googleapis.com/auth/spreadsheets.readonly",
+]
+
 
 class GoogleClient:
     """Lightweight wrapper around Google service clients."""


### PR DESCRIPTION
## Summary
- expose `SCOPES` constant in `google_client`
- reference this in tests

## Testing
- `ruff check schedule_app/services/google_client.py tests/unit/test_google_client_import.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e95d069b0832da2b733e742e62dfa