### PR TITLE
Implement OAuth2 login with PKCE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask==2.3.*
 google-auth==2.*
 google-api-python-client==2.*
+google-auth-oauthlib>=1.2.0

--- a/schedule_app/__init__.py
+++ b/schedule_app/__init__.py
@@ -7,10 +7,93 @@ only inside :func:`create_app`.
 
 from __future__ import annotations
 
+import json
+import os
+
+try:
+    from google_auth_oauthlib.flow import Flow  # type: ignore
+    import google.oauth2.credentials as gcreds  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    Flow = None  # type: ignore
+    gcreds = None  # type: ignore
+
 try:  # Flask may be absent in some test environments
     from flask import Flask  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     Flask = None  # type: ignore
+
+
+def login() -> "Response":
+    from flask import current_app, redirect, request, session
+
+    if Flow is None:
+        raise RuntimeError("google-auth-oauthlib is required")
+
+    client_id = os.getenv("GOOGLE_CLIENT_ID") or current_app.config.get("GOOGLE_CLIENT_ID")
+    client_secret = os.getenv("GOOGLE_CLIENT_SECRET") or current_app.config.get("GOOGLE_CLIENT_SECRET")
+    redirect_uri = os.getenv("GOOGLE_REDIRECT_URI") or current_app.config.get("GOOGLE_REDIRECT_URI")
+
+    flow = Flow.from_client_config(
+        {
+            "web": {
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "redirect_uris": [redirect_uri],
+            }
+        },
+        scopes=[
+            "openid",
+            "profile",
+            "email",
+            "https://www.googleapis.com/auth/calendar.readonly",
+            "https://www.googleapis.com/auth/spreadsheets",
+        ],
+        redirect_uri=redirect_uri,
+    )
+
+    authorization_url, state = flow.authorization_url(
+        include_granted_scopes="true", code_challenge_method="S256"
+    )
+    session["pkce_state"] = state
+    return redirect(authorization_url)
+
+
+def oauth2_cb() -> "Response":
+    from flask import current_app, redirect, request, session, url_for
+
+    if Flow is None:
+        raise RuntimeError("google-auth-oauthlib is required")
+
+    state = request.args.get("state")
+    if not state or state != session.get("pkce_state"):
+        return "Invalid state parameter", 400
+
+    client_id = os.getenv("GOOGLE_CLIENT_ID") or current_app.config.get("GOOGLE_CLIENT_ID")
+    client_secret = os.getenv("GOOGLE_CLIENT_SECRET") or current_app.config.get("GOOGLE_CLIENT_SECRET")
+    redirect_uri = os.getenv("GOOGLE_REDIRECT_URI") or current_app.config.get("GOOGLE_REDIRECT_URI")
+
+    flow = Flow.from_client_config(
+        {
+            "web": {
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "redirect_uris": [redirect_uri],
+            }
+        },
+        scopes=[
+            "openid",
+            "profile",
+            "email",
+            "https://www.googleapis.com/auth/calendar.readonly",
+            "https://www.googleapis.com/auth/spreadsheets",
+        ],
+        redirect_uri=redirect_uri,
+    )
+
+    flow.fetch_token(code=request.args.get("code"))
+    creds_dict = json.loads(flow.credentials.to_json())
+    session["google_creds"] = creds_dict
+    return redirect(url_for("index"))
 
 def create_app() -> Flask:  # type: ignore[name-defined]
     """Return a minimal Flask application."""
@@ -30,6 +113,9 @@ def create_app() -> Flask:  # type: ignore[name-defined]
     @app.get("/")
     def index():
         return render_template("index.html")
+
+    app.add_url_rule("/login", "login", login)
+    app.add_url_rule("/callback", "oauth2_cb", oauth2_cb)
 
     return app
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from schedule_app import create_app
+
+
+@pytest.fixture
+def app():
+    os.environ.setdefault("GOOGLE_CLIENT_ID", "dummy-client-id")
+    os.environ.setdefault("GOOGLE_CLIENT_SECRET", "dummy-secret")
+    os.environ.setdefault("GOOGLE_REDIRECT_URI", "http://localhost:5173/callback")
+    app = create_app()
+    app.testing = True
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1,0 +1,34 @@
+import re
+from unittest.mock import patch, MagicMock
+from urllib.parse import urlparse, parse_qs
+
+
+def test_login_redirect(client):
+    """/login は Google 認可 URL へリダイレクトする"""
+    resp = client.get("/login")
+    assert resp.status_code == 302
+    url = resp.headers["Location"]
+    assert "accounts.google.com" in url
+    parsed = urlparse(url)
+    qs = parse_qs(parsed.query)
+    # code_challenge, state, client_id を含むこと
+    assert "code_challenge" in qs and qs["code_challenge_method"] == ["S256"]
+
+
+@patch("schedule_app.__init__.Flow")
+def test_callback_exchange(mock_flow, client, app):
+    """/callback はトークン交換後 index へリダイレクトする"""
+    # ダミーフロー: fetch_token→None, credentials→MagicMock(to_json)
+    dummy_creds = MagicMock(to_json=lambda: '{"token":"ya29..."}')
+    mock_instance = MagicMock(
+        fetch_token=lambda code: None,
+        credentials=dummy_creds,
+    )
+    mock_flow.from_client_config.return_value = mock_instance
+    with client.session_transaction() as sess:
+        sess["pkce_state"] = "abc123"
+    resp = client.get("/callback?state=abc123&code=authcode")
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/")
+    with client.session_transaction() as sess:
+        assert "google_creds" in sess


### PR DESCRIPTION
## Summary
- add OAuth2 PKCE login and callback routes
- add `google-auth-oauthlib` requirement
- add integration tests for auth

## Testing
- `pytest tests/integration/test_auth.py -q` *(fails: Flask not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6861cbe9fb64832da7534445c9469801