### PR TITLE
Update development requirements

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -9,3 +9,4 @@ httpretty==1.*
 playwright==1.*
 pre-commit==3.*
 pip-audit==2.*
+google-auth-oauthlib>=1.2.0


### PR DESCRIPTION
## Summary
- add `google-auth-oauthlib>=1.2.0` to development dependencies

## Testing
- `pytest -q`
- `pre-commit run --files requirements.dev.txt` *(fails: `pre-commit` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6861d8d9127c832d92713442d5f6f252