### PR TITLE
Handle missing google-auth-oauthlib

### DIFF
--- a/schedule_app/__init__.py
+++ b/schedule_app/__init__.py
@@ -12,6 +12,18 @@ try:  # Flask may be absent in some test environments
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     Flask = None  # type: ignore
 
+try:
+    from google_auth_oauthlib.flow import Flow  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    Flow = None  # type: ignore
+
+
+def _build_flow(*, redirect_uri: str) -> Flow:  # pragma: no cover - placeholder
+    """Return an OAuth2 Flow object."""
+    if Flow is None:
+        raise RuntimeError("google-auth-oauthlib is required")
+    raise NotImplementedError
+
 def create_app() -> Flask:  # type: ignore[name-defined]
     """Return a minimal Flask application."""
     if Flask is None:  # pragma: no cover - import guard for tests


### PR DESCRIPTION
## Summary
- optionally import `Flow` in `schedule_app.__init__`
- guard `_build_flow` so runtime error is raised if Flow is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861d8d9d1b4832db2fee150f5a5c898