### PR TITLE
Implement OAuth2 login routes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask==2.3.*
 google-auth==2.*
 google-api-python-client==2.*
+google-auth-oauthlib>=1.2.0


### PR DESCRIPTION
## Summary
- introduce Google OAuth2 PKCE flow builder
- add `/login` and `/callback` routes
- set secret key from `FLASK_SECRET_KEY` env var
- install `google-auth-oauthlib`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google_auth_oauthlib')*

------
https://chatgpt.com/codex/tasks/task_e_6861d5ea19e0832d9588156a4d59e274