### PR TITLE
Implement OAuth2 PKCE login flow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask==2.3.*
 google-auth==2.*
 google-api-python-client==2.*
+google-auth-oauthlib>=1.2.0


### PR DESCRIPTION
## Summary
- implement `_build_flow` helper for PKCE
- add `/login` and `/callback` routes
- configure a fixed `secret_key`
- add `google-auth-oauthlib` runtime dependency

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e2478a14832d86704baa79f773b2