### PR TITLE
Support testing mode in create_app

### DIFF
--- a/schedule_app/__init__.py
+++ b/schedule_app/__init__.py
@@ -64,8 +64,14 @@ def _build_flow(*, redirect_uri: str) -> Flow:
         redirect_uri=redirect_uri,
     )
 
-def create_app() -> Flask:  # type: ignore[name-defined]
-    """Return a minimal Flask application."""
+def create_app(*, testing: bool = False) -> Flask:  # type: ignore[name-defined]
+    """Return a minimal Flask application.
+
+    Parameters
+    ----------
+    testing:
+        When ``True``, enable Flask testing mode and disable CSRF protection.
+    """
     if Flask is None:  # pragma: no cover - import guard for tests
         raise RuntimeError("Flask is required to create the application")
 
@@ -73,6 +79,9 @@ def create_app() -> Flask:  # type: ignore[name-defined]
 
     app = Flask(__name__)
     app.secret_key = "dev-secret-key"
+
+    if testing:
+        app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
 
     # ヘルスチェック用エンドポイント
     @app.get("/api/health")

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -30,8 +30,8 @@ def app():
     """Real Flask app from create_app(), in TESTING mode."""
     from schedule_app import create_app
 
-    flask_app = create_app()
-    flask_app.config.update(TESTING=True, SECRET_KEY="test-secret")
+    flask_app = create_app(testing=True)
+    flask_app.config.update(SECRET_KEY="test-secret")
     return flask_app
 
 


### PR DESCRIPTION
## Summary
- extend `create_app` to accept a `testing` flag
- allow tests to request a Flask test app with CSRF disabled

## Testing
- `pytest -q` *(fails: Flask missing)*

------
https://chatgpt.com/codex/tasks/task_e_6861fe97617c832d945a65f84c164046