### PR TITLE
Add calendar events integration test

### DIFF
--- a/schedule_app/services/google_client.py
+++ b/schedule_app/services/google_client.py
@@ -8,6 +8,8 @@ added later.
 from __future__ import annotations
 
 from typing import Any
+from urllib import parse, request
+import json
 
 
 # OAuth scopes required for accessing Google APIs
@@ -35,3 +37,29 @@ class GoogleClient:
     def sheets_service(self) -> Any:
         """Return a Google Sheets service client (stub)."""
         raise NotImplementedError
+
+    def fetch_calendar_events(self, *, time_min: str, time_max: str) -> list[dict]:
+        """Fetch calendar events within the given time range.
+
+        Parameters
+        ----------
+        time_min: str
+            ISO 8601 start datetime in UTC.
+        time_max: str
+            ISO 8601 end datetime in UTC.
+        """
+
+        query = parse.urlencode(
+            {
+                "timeMin": time_min,
+                "timeMax": time_max,
+                "singleEvents": "true",
+            }
+        )
+        url = (
+            "https://www.googleapis.com/calendar/v3/calendars/primary/events?" + query
+        )
+        req = request.Request(url)
+        with request.urlopen(req) as resp:  # pragma: no cover - network stubbed
+            data = json.loads(resp.read().decode())
+        return data.get("items", [])

--- a/tests/integration/test_calendar.py
+++ b/tests/integration/test_calendar.py
@@ -5,6 +5,7 @@ import re
 from unittest.mock import MagicMock
 
 import httpretty
+from urllib import parse
 import pytest
 
 from schedule_app.services.google_client import GoogleClient
@@ -22,9 +23,15 @@ def test_fetch_calendar_events_request_url(client):
     url_re = re.compile(
         r"https://www.googleapis.com/calendar/v3/calendars/primary/events.*"
     )
+    query = parse.urlencode(
+        {
+            "timeMin": start,
+            "timeMax": end,
+            "singleEvents": "true",
+        }
+    )
     expected_url = (
-        "https://www.googleapis.com/calendar/v3/calendars/primary/events"
-        f"?timeMin={start}&timeMax={end}&singleEvents=true"
+        "https://www.googleapis.com/calendar/v3/calendars/primary/events?" + query
     )
 
     httpretty.enable()

--- a/tests/integration/test_calendar.py
+++ b/tests/integration/test_calendar.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import re
+from unittest.mock import MagicMock
+
+import httpretty
+import pytest
+
+from schedule_app.services.google_client import GoogleClient
+
+
+@pytest.fixture()
+def client():
+    return GoogleClient(credentials=MagicMock())
+
+
+def test_fetch_calendar_events_request_url(client):
+    start = "2025-01-01T00:00:00Z"
+    end = "2025-01-02T00:00:00Z"
+
+    url_re = re.compile(
+        r"https://www.googleapis.com/calendar/v3/calendars/primary/events.*"
+    )
+    expected_url = (
+        "https://www.googleapis.com/calendar/v3/calendars/primary/events"
+        f"?timeMin={start}&timeMax={end}&singleEvents=true"
+    )
+
+    httpretty.enable()
+    httpretty.register_uri(
+        httpretty.GET,
+        uri=url_re,
+        body=json.dumps({"items": []}),
+        status=200,
+    )
+    try:
+        client.fetch_calendar_events(time_min=start, time_max=end)
+        assert httpretty.last_request().url == expected_url
+    finally:
+        httpretty.disable()
+        httpretty.reset()


### PR DESCRIPTION
## Summary
- support calendar event fetching via `GoogleClient.fetch_calendar_events`
- add integration test using httpretty to check the request URL

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpretty')*

------
https://chatgpt.com/codex/tasks/task_e_6861fe984dbc832db08b9615311daf9c