### PR TITLE
Add API package blueprint placeholder

### DIFF
--- a/schedule_app/api/__init__.py
+++ b/schedule_app/api/__init__.py
@@ -1,0 +1,11 @@
+"""Flask blueprints for the REST API."""
+
+from __future__ import annotations
+
+# Re-export commonly used blueprints
+try:
+    from .calendar import bp as calendar_bp  # type: ignore
+except Exception:  # pragma: no cover - optional blueprint
+    pass
+
+__all__ = [name for name in globals() if name.endswith('_bp')]


### PR DESCRIPTION
## Summary
- create API package with optional blueprint

## Testing
- `pytest -q` *(fails: RuntimeError: Flask is required to create the application)*

------
https://chatgpt.com/codex/tasks/task_e_6861fe9a1b7c832dbff50ec101532653