### PR TITLE
Add timezone support in quantize

### DIFF
--- a/tests/unit/test_rounding.py
+++ b/tests/unit/test_rounding.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 import sys
 
@@ -22,3 +22,10 @@ def test_quantize(iso: str, up: bool, expected: str) -> None:
     dt = datetime.fromisoformat(iso.replace("Z", "+00:00")).replace(tzinfo=None)
     want = datetime.fromisoformat(expected.replace("Z", "+00:00"))
     assert quantize(dt, up=up) == want
+
+
+def test_quantize_with_timezone() -> None:
+    jst = timezone(timedelta(hours=9))
+    dt = datetime(2025, 1, 1, 9, 5, tzinfo=jst)
+    want = datetime(2025, 1, 1, 9, 0, tzinfo=jst)
+    assert quantize(dt, up=False, tz=jst) == want


### PR DESCRIPTION
## Summary
- allow choosing timezone in the `quantize` helper
- cover timezone-aware cases in rounding tests

## Testing
- `pytest -q` *(fails: Flask missing)*

------
https://chatgpt.com/codex/tasks/task_e_6861fe9a4094832da45b9af2a81db84f