### PR TITLE
Add pytest warning filter

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning:httpretty.*


### PR DESCRIPTION
## Summary
- add pytest.ini to filter HTTPretty DeprecationWarnings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpretty')*

------
https://chatgpt.com/codex/tasks/task_e_686209d70444832dae5161c0bca2751b