### PR TITLE
Implement GoogleClient.list_events

### DIFF
--- a/schedule_app/api/calendar.py
+++ b/schedule_app/api/calendar.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from flask import Blueprint, abort, current_app, jsonify, request
 from google.auth.exceptions import RefreshError
@@ -24,13 +24,10 @@ def get_calendar() -> tuple[list[dict], int] | tuple[dict, int]:
     except ValueError:
         abort(400, description="invalid date format")
 
-    start_utc = datetime.combine(date_obj, datetime.min.time())
-    end_utc = start_utc + timedelta(days=1)
-
     client: GoogleClient = current_app.extensions["gclient"]
 
     try:
-        events = client.list_events(start_utc=start_utc, end_utc=end_utc)
+        events = client.list_events(date=date_obj)
     except RefreshError:
         abort(401)
     except HttpError as exc:

--- a/tests/unit/test_google_client_list.py
+++ b/tests/unit/test_google_client_list.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from schedule_app.services.google_client import GoogleClient
+
+
+def test_list_events_range(monkeypatch):
+    client = GoogleClient(credentials=None)
+
+    captured = {}
+
+    def fake_fetch(*, time_min: str, time_max: str):
+        captured["time_min"] = time_min
+        captured["time_max"] = time_max
+        return []
+
+    monkeypatch.setattr(client, "fetch_calendar_events", fake_fetch)
+
+    client.list_events(date=datetime(2025, 1, 1))
+
+    assert captured["time_min"] == "2025-01-01T00:00:00Z"
+    assert captured["time_max"] == "2025-01-02T00:00:00Z"
+
+


### PR DESCRIPTION
## Summary
- add `GoogleClient.list_events` helper that converts a date to a UTC range
- call new helper from calendar API blueprint
- document list_events in the module docstring
- test that list_events calls `fetch_calendar_events` with the expected range

## Testing
- `ruff check schedule_app/api/calendar.py schedule_app/services/google_client.py tests/unit/test_google_client_list.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpretty')*


------
https://chatgpt.com/codex/tasks/task_e_68620fd2a198832da23f8f0a0382f111