### PR TITLE
Expose calendar_bp

### DIFF
--- a/schedule_app/api/__init__.py
+++ b/schedule_app/api/__init__.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 # Explicitly export optional blueprints
-__all__ = ["bp_calendar"]
+__all__ = ["calendar_bp"]
 
 try:
-    from .calendar import bp_calendar  # type: ignore
+    from .calendar import calendar_bp  # type: ignore
 except Exception:  # pragma: no cover - optional blueprint
-    bp_calendar = None  # type: ignore
+    calendar_bp = None  # type: ignore

--- a/schedule_app/api/calendar.py
+++ b/schedule_app/api/calendar.py
@@ -10,10 +10,11 @@ from googleapiclient.errors import HttpError
 from schedule_app.services.google_client import GoogleClient
 
 
-bp_calendar = Blueprint("bp_calendar", __name__)
+bp = Blueprint("calendar_bp", __name__)
+calendar_bp = bp
 
 
-@bp_calendar.get("/api/calendar")
+@bp.get("/api/calendar")
 def get_calendar() -> tuple[list[dict], int] | tuple[dict, int]:
     date_str = request.args.get("date")
     if not date_str:
@@ -46,4 +47,4 @@ def get_calendar() -> tuple[list[dict], int] | tuple[dict, int]:
     return jsonify([asdict(ev) for ev in events]), 200
 
 
-__all__ = ["bp_calendar"]
+__all__ = ["calendar_bp"]


### PR DESCRIPTION
## Summary
- alias blueprint as `calendar_bp`
- update API init to export `calendar_bp`

## Testing
- `ruff check schedule_app/api/calendar.py schedule_app/api/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpretty')*

------
https://chatgpt.com/codex/tasks/task_e_68620fd43a4c832d91f5093f07cbe0aa