### PR TITLE
Add tasks API blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,16 @@ Execute the unit tests with:
 pytest -q
 ```
 
+
+## Tasks API
+
+Simple in-memory endpoints used by the front-end.
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| GET | `/api/tasks` | List all tasks |
+| POST | `/api/tasks` | Create a task |
+| PUT | `/api/tasks/<id>` | Update a task |
+| DELETE | `/api/tasks/<id>` | Remove a task |
+
+All datetimes are UTC RFC 3339 strings. Validation errors return a 422 response with type `https://schedule.app/errors/invalid-field`.

--- a/schedule_app/api/__init__.py
+++ b/schedule_app/api/__init__.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 # Explicitly export optional blueprints
-__all__ = ["calendar_bp"]
+__all__ = ["calendar_bp", "tasks_bp"]
 
 try:
     from .calendar import calendar_bp  # type: ignore
 except Exception:  # pragma: no cover - optional blueprint
     calendar_bp = None  # type: ignore
+
+try:
+    from .tasks import bp as tasks_bp  # type: ignore
+except Exception:  # pragma: no cover - optional blueprint
+    tasks_bp = None  # type: ignore

--- a/schedule_app/api/tasks.py
+++ b/schedule_app/api/tasks.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime, timezone
+
+from flask import Blueprint, abort, jsonify, request
+from werkzeug.exceptions import HTTPException
+
+from schedule_app.models import Task
+
+
+bp = Blueprint("tasks", __name__, url_prefix="/api/tasks")
+
+# in-memory task storage
+TASKS: dict[str, Task] = {}
+
+
+def _parse_dt(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        abort(422, description="invalid datetime")
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt
+
+
+def _task_to_dict(task: Task) -> dict:
+    data = asdict(task)
+    if task.earliest_start_utc is not None:
+        data["earliest_start_utc"] = task.earliest_start_utc.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    else:
+        data["earliest_start_utc"] = None
+    return data
+
+
+@bp.errorhandler(HTTPException)
+def handle_http_error(exc: HTTPException):
+    payload = {"type": "about:blank", "title": exc.name, "status": exc.code}
+    if exc.code == 422:
+        payload["type"] = "https://schedule.app/errors/invalid-field"
+    if exc.description:
+        payload["detail"] = exc.description
+    return jsonify(payload), exc.code
+
+
+@bp.get("")
+def list_tasks():
+    return jsonify([_task_to_dict(t) for t in TASKS.values()])
+
+
+@bp.post("")
+def create_task():
+    data = request.get_json() or {}
+    try:
+        duration_raw = int(data.get("duration_raw_min"))
+        duration = int(data.get("duration_min"))
+    except (TypeError, ValueError):
+        abort(422, description="invalid duration")
+
+    if duration_raw <= 0 or duration_raw % 5 != 0:
+        abort(422, description="duration_raw_min must be positive multiple of 5")
+    if duration % 10 != 0:
+        abort(422, description="duration_min must be multiple of 10")
+
+    task_id = data.get("id")
+    if not task_id:
+        abort(422, description="id required")
+
+    task = Task(
+        id=task_id,
+        title=data.get("title", ""),
+        category=data.get("category", ""),
+        duration_min=duration,
+        duration_raw_min=duration_raw,
+        priority=data.get("priority", "A"),
+        earliest_start_utc=_parse_dt(data.get("earliest_start_utc")),
+    )
+    TASKS[task_id] = task
+    return jsonify(_task_to_dict(task)), 201
+
+
+@bp.put("/<id>")
+def update_task(id: str):
+    if id not in TASKS:
+        abort(404)
+
+    data = request.get_json() or {}
+    try:
+        duration_raw = int(data.get("duration_raw_min"))
+        duration = int(data.get("duration_min"))
+    except (TypeError, ValueError):
+        abort(422, description="invalid duration")
+
+    if duration_raw <= 0 or duration_raw % 5 != 0:
+        abort(422, description="duration_raw_min must be positive multiple of 5")
+    if duration % 10 != 0:
+        abort(422, description="duration_min must be multiple of 10")
+
+    task = Task(
+        id=id,
+        title=data.get("title", ""),
+        category=data.get("category", ""),
+        duration_min=duration,
+        duration_raw_min=duration_raw,
+        priority=data.get("priority", "A"),
+        earliest_start_utc=_parse_dt(data.get("earliest_start_utc")),
+    )
+    TASKS[id] = task
+    return jsonify(_task_to_dict(task)), 200
+
+
+@bp.delete("/<id>")
+def delete_task(id: str):
+    if id not in TASKS:
+        abort(404)
+    TASKS.pop(id)
+    return "", 204
+
+
+__all__ = ["bp"]

--- a/tests/integration/test_tasks.py
+++ b/tests/integration/test_tasks.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from flask import Flask
+
+from schedule_app import create_app
+from schedule_app.api.tasks import bp as tasks_bp, TASKS
+
+
+@pytest.fixture()
+def app() -> Flask:
+    flask_app = create_app(testing=True)
+    flask_app.register_blueprint(tasks_bp)
+    return flask_app
+
+
+@pytest.fixture()
+def client(app: Flask):
+    TASKS.clear()
+    return app.test_client()
+
+
+def _assert_problem_details(data: Any) -> None:
+    assert isinstance(data, dict)
+    for key in ("type", "title", "status"):
+        assert key in data
+
+
+def test_list_empty(client) -> None:
+    resp = client.get("/api/tasks")
+    assert resp.status_code == 200
+    assert resp.get_json() == []
+
+
+def test_create_and_get(client) -> None:
+    payload = {
+        "id": "1",
+        "title": "Task",
+        "category": "general",
+        "duration_min": 20,
+        "duration_raw_min": 25,
+        "priority": "A",
+        "earliest_start_utc": "2025-01-01T09:00:00Z",
+    }
+    resp = client.post("/api/tasks", json=payload)
+    assert resp.status_code == 201
+    data = resp.get_json()
+    assert data["id"] == "1"
+    assert data["earliest_start_utc"] == "2025-01-01T09:00:00Z"
+
+    resp = client.get("/api/tasks")
+    assert len(resp.get_json()) == 1
+
+
+def test_validation_error(client) -> None:
+    payload = {
+        "id": "x",
+        "title": "bad",
+        "category": "g",
+        "duration_min": 21,
+        "duration_raw_min": 7,
+        "priority": "A",
+    }
+    resp = client.post("/api/tasks", json=payload)
+    assert resp.status_code == 422
+    _assert_problem_details(resp.get_json())
+
+
+def test_update_not_found(client) -> None:
+    resp = client.put("/api/tasks/404", json={"duration_min": 10, "duration_raw_min": 10})
+    assert resp.status_code == 404
+    _assert_problem_details(json.loads(resp.data))
+
+
+def test_update_and_delete(client) -> None:
+    payload = {
+        "id": "2",
+        "title": "T",
+        "category": "c",
+        "duration_min": 10,
+        "duration_raw_min": 10,
+        "priority": "B",
+    }
+    client.post("/api/tasks", json=payload)
+
+    upd = payload | {"title": "Updated"}
+    resp = client.put("/api/tasks/2", json=upd)
+    assert resp.status_code == 200
+    assert resp.get_json()["title"] == "Updated"
+
+    del_resp = client.delete("/api/tasks/2")
+    assert del_resp.status_code == 204
+
+    resp = client.get("/api/tasks")
+    assert resp.get_json() == []
+


### PR DESCRIPTION
## Summary
- implement `/api/tasks` blueprint with in-memory store
- handle errors with Problem Details JSON
- export blueprint from `schedule_app.api`
- document tasks endpoints
- add integration tests for CRUD behaviour

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68621fd2c0a4832dbed4e13133144577