### PR TITLE
Implement tasks API blueprint

### DIFF
--- a/schedule_app/api/tasks.py
+++ b/schedule_app/api/tasks.py
@@ -2,124 +2,141 @@ from __future__ import annotations
 
 from dataclasses import asdict
 from datetime import datetime, timezone
+from typing import Any
 
-from flask import Blueprint, abort, jsonify, request
-from werkzeug.exceptions import HTTPException
+from flask import Blueprint, abort, jsonify, request, url_for
 
 from schedule_app.models import Task
 
-
 bp = Blueprint("tasks", __name__, url_prefix="/api/tasks")
 
-# in-memory task storage
+# プロセス内メモリに保持（サーバ再起動で消える）
 TASKS: dict[str, Task] = {}
+
+__all__ = ["bp", "TASKS"]
+
+# ---------------------------------------------------------------------------
+# 内部ユーティリティ
+# ---------------------------------------------------------------------------
+
+
+def _problem(status: int, code: str, detail: str):
+    """Problem Details 仕様フォーマットで abort する。"""
+    response = jsonify(
+        {
+            "type": f"https://schedule.app/errors/{code}",
+            "title": "Validation failed" if status == 422 else "Not found",
+            "status": status,
+            "detail": detail,
+        }
+    )
+    response.status_code = status
+    abort(response)
 
 
 def _parse_dt(value: str | None) -> datetime | None:
-    if not value:
+    if value is None:
         return None
+    # “Z” 終端を許容して UTC に統一
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
     try:
-        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return datetime.fromisoformat(value).astimezone(timezone.utc)
     except ValueError:
-        abort(422, description="invalid datetime")
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    else:
-        dt = dt.astimezone(timezone.utc)
-    return dt
+        _problem(422, "invalid-field", "Invalid datetime format.")
 
 
-def _task_to_dict(task: Task) -> dict:
-    data = asdict(task)
-    if task.earliest_start_utc is not None:
-        data["earliest_start_utc"] = task.earliest_start_utc.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
-    else:
-        data["earliest_start_utc"] = None
-    return data
+def _validate_durations(duration_min: int, duration_raw_min: int) -> None:
+    ok = (
+        isinstance(duration_min, int)
+        and isinstance(duration_raw_min, int)
+        and duration_min > 0
+        and duration_raw_min > 0
+        and duration_min % 10 == 0
+        and duration_raw_min % 5 == 0
+    )
+    if not ok:
+        _problem(
+            422,
+            "invalid-field",
+            "Duration must be positive; raw multiple of 5, rounded multiple of 10.",
+        )
 
 
-@bp.errorhandler(HTTPException)
-def handle_http_error(exc: HTTPException):
-    payload = {"type": "about:blank", "title": exc.name, "status": exc.code}
-    if exc.code == 422:
-        payload["type"] = "https://schedule.app/errors/invalid-field"
-    if exc.description:
-        payload["detail"] = exc.description
-    return jsonify(payload), exc.code
+def _task_from_json(data: dict[str, Any]) -> Task:
+    required = {"id", "title", "category", "duration_min", "duration_raw_min", "priority"}
+    missing = required - data.keys()
+    if missing:
+        _problem(422, "invalid-field", f"Missing field(s): {', '.join(sorted(missing))}")
+
+    _validate_durations(data["duration_min"], data["duration_raw_min"])
+
+    return Task(
+        id=data["id"],
+        title=data["title"],
+        category=data["category"],
+        duration_min=data["duration_min"],
+        duration_raw_min=data["duration_raw_min"],
+        priority=data["priority"],
+        earliest_start_utc=_parse_dt(data.get("earliest_start_utc")),
+    )
+
+
+def _serialize(task: Task) -> dict[str, Any]:
+    d = asdict(task)
+    if d["earliest_start_utc"] is not None:
+        d["earliest_start_utc"] = (
+            d["earliest_start_utc"].astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+        )
+    return d
+
+
+# ---------------------------------------------------------------------------
+# ルーティング
+# ---------------------------------------------------------------------------
 
 
 @bp.get("")
 def list_tasks():
-    return jsonify([_task_to_dict(t) for t in TASKS.values()])
+    """すべての Task を返す."""
+    return jsonify([_serialize(t) for t in TASKS.values()])
 
 
 @bp.post("")
 def create_task():
-    data = request.get_json() or {}
-    try:
-        duration_raw = int(data.get("duration_raw_min"))
-        duration = int(data.get("duration_min"))
-    except (TypeError, ValueError):
-        abort(422, description="invalid duration")
+    data = request.get_json(force=True, silent=False)
+    task = _task_from_json(data)
+    TASKS[task.id] = task
 
-    if duration_raw <= 0 or duration_raw % 5 != 0:
-        abort(422, description="duration_raw_min must be positive multiple of 5")
-    if duration % 10 != 0:
-        abort(422, description="duration_min must be multiple of 10")
+    resp = jsonify(_serialize(task))
+    resp.status_code = 201
+    resp.headers["Location"] = url_for(".get_task", id=task.id)
+    return resp
 
-    task_id = data.get("id")
-    if not task_id:
-        abort(422, description="id required")
 
-    task = Task(
-        id=task_id,
-        title=data.get("title", ""),
-        category=data.get("category", ""),
-        duration_min=duration,
-        duration_raw_min=duration_raw,
-        priority=data.get("priority", "A"),
-        earliest_start_utc=_parse_dt(data.get("earliest_start_utc")),
-    )
-    TASKS[task_id] = task
-    return jsonify(_task_to_dict(task)), 201
+@bp.get("/<id>")
+def get_task(id: str):
+    task = TASKS.get(id)
+    if task is None:
+        _problem(404, "not-found", "Task not found.")
+    return jsonify(_serialize(task))
 
 
 @bp.put("/<id>")
 def update_task(id: str):
     if id not in TASKS:
-        abort(404)
+        _problem(404, "not-found", "Task not found.")
 
-    data = request.get_json() or {}
-    try:
-        duration_raw = int(data.get("duration_raw_min"))
-        duration = int(data.get("duration_min"))
-    except (TypeError, ValueError):
-        abort(422, description="invalid duration")
-
-    if duration_raw <= 0 or duration_raw % 5 != 0:
-        abort(422, description="duration_raw_min must be positive multiple of 5")
-    if duration % 10 != 0:
-        abort(422, description="duration_min must be multiple of 10")
-
-    task = Task(
-        id=id,
-        title=data.get("title", ""),
-        category=data.get("category", ""),
-        duration_min=duration,
-        duration_raw_min=duration_raw,
-        priority=data.get("priority", "A"),
-        earliest_start_utc=_parse_dt(data.get("earliest_start_utc")),
-    )
+    data = request.get_json(force=True, silent=False) or {}
+    data["id"] = id  # ID の整合性を保証
+    task = _task_from_json(data)
     TASKS[id] = task
-    return jsonify(_task_to_dict(task)), 200
+    return jsonify(_serialize(task))
 
 
 @bp.delete("/<id>")
 def delete_task(id: str):
     if id not in TASKS:
-        abort(404)
-    TASKS.pop(id)
-    return "", 204
-
-
-__all__ = ["bp"]
+        _problem(404, "not-found", "Task not found.")
+    del TASKS[id]
+    return ("", 204)


### PR DESCRIPTION
## Summary
- replace tasks API blueprint implementation

## Testing
- `ruff check schedule_app/api/tasks.py`
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_6862235a22c0832d81cc50989aa763db