### PR TITLE
Register API blueprints automatically

### DIFF
--- a/schedule_app/__init__.py
+++ b/schedule_app/__init__.py
@@ -84,6 +84,14 @@ def create_app(*, testing: bool = False) -> Flask:  # type: ignore[name-defined]
     if testing:
         app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
 
+    from schedule_app.api import calendar_bp, tasks_bp
+
+    if calendar_bp is not None:
+        app.register_blueprint(calendar_bp)
+
+    if tasks_bp is not None:
+        app.register_blueprint(tasks_bp)
+
     # ヘルスチェック用エンドポイント
     @app.get("/api/health")
     def health():

--- a/tests/integration/test_calendar.py
+++ b/tests/integration/test_calendar.py
@@ -9,7 +9,7 @@ from freezegun import freeze_time
 from flask import Flask
 
 from schedule_app import create_app
-from schedule_app.api.calendar import calendar_bp, HttpError, RefreshError
+from schedule_app.api.calendar import HttpError, RefreshError
 from schedule_app.models import Event
 
 
@@ -29,7 +29,6 @@ class DummyGClient:
 @pytest.fixture()
 def app() -> Flask:
     flask_app = create_app(testing=True)
-    flask_app.register_blueprint(calendar_bp)
     return flask_app
 
 

--- a/tests/integration/test_tasks.py
+++ b/tests/integration/test_tasks.py
@@ -7,13 +7,12 @@ import pytest
 from flask import Flask
 
 from schedule_app import create_app
-from schedule_app.api.tasks import bp as tasks_bp, TASKS
+from schedule_app.api.tasks import TASKS
 
 
 @pytest.fixture()
 def app() -> Flask:
     flask_app = create_app(testing=True)
-    flask_app.register_blueprint(tasks_bp)
     return flask_app
 
 


### PR DESCRIPTION
## Summary
- register API blueprints from `schedule_app.api` directly in the application factory
- adjust integration tests to rely on automatic blueprint registration

## Testing
- `pre-commit run --files schedule_app/__init__.py tests/integration/test_calendar.py tests/integration/test_tasks.py` *(fails: command not found)*
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686230ac27f0832d85e21300a60e0960