### PR TITLE
Improve test setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ The `requirements.dev.txt` file includes **freezegun**, which the tests rely on.
 
 ## Running Tests
 
-Execute the unit tests with:
+Install the development requirements and then execute the unit tests with:
 
 ```bash
+pip install -r requirements.dev.txt
 pytest -q
 ```
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,9 @@
 # tests/conftest.py  ★新規
+"""Pytest configuration.
+
+Tests rely on ``freezegun`` for time manipulation. They are skipped if the
+package isn't installed.
+"""
 import sys
 import pathlib
 import importlib


### PR DESCRIPTION
## Summary
- mention installing dev requirements before running `pytest`
- clarify in `conftest.py` why tests require `freezegun`

## Testing
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_686230aed4dc832da09b3259e0ae0d16