### PR TITLE
Remove unused google creds import

### DIFF
--- a/schedule_app/__init__.py
+++ b/schedule_app/__init__.py
@@ -17,11 +17,9 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency
 
 try:
     from google_auth_oauthlib.flow import Flow  # type: ignore
-    import google.oauth2.credentials as gcreds  # type: ignore
     from flask import session, redirect, url_for, abort  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     Flow = None  # type: ignore
-    gcreds = None  # type: ignore
 
 
 def _get_setting(name: str) -> str | None:


### PR DESCRIPTION
## Summary
- remove the unused import of `google.oauth2.credentials`
- keep Flow import guard for optional dependency

## Testing
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_686230b54a48832dbdd00fdada17d0cf