### PR TITLE
Validate task priority

### DIFF
--- a/schedule_app/api/tasks.py
+++ b/schedule_app/api/tasks.py
@@ -73,6 +73,9 @@ def _task_from_json(data: dict[str, Any]) -> Task:
 
     _validate_durations(data["duration_min"], data["duration_raw_min"])
 
+    if data["priority"] not in {"A", "B"}:
+        _problem(422, "invalid-field", "Priority must be 'A' or 'B'.")
+
     return Task(
         id=data["id"],
         title=data["title"],

--- a/tests/integration/test_tasks.py
+++ b/tests/integration/test_tasks.py
@@ -69,6 +69,20 @@ def test_validation_error(client) -> None:
     _assert_problem_details(resp.get_json())
 
 
+def test_invalid_priority(client) -> None:
+    payload = {
+        "id": "p",
+        "title": "badprio",
+        "category": "g",
+        "duration_min": 10,
+        "duration_raw_min": 10,
+        "priority": "C",
+    }
+    resp = client.post("/api/tasks", json=payload)
+    assert resp.status_code == 422
+    _assert_problem_details(resp.get_json())
+
+
 def test_update_not_found(client) -> None:
     resp = client.put("/api/tasks/404", json={"duration_min": 10, "duration_raw_min": 10})
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- validate priority field when creating or updating a task
- test that invalid priorities return an error

## Testing
- `pre-commit run --files schedule_app/api/tasks.py tests/integration/test_tasks.py` *(fails: command not found)*
- `pytest -q` *(fails: freezegun not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686230aef5e4832d8c70ed29499c757e