### PR TITLE
Automatic IDs for new tasks

### DIFF
--- a/schedule_app/api/tasks.py
+++ b/schedule_app/api/tasks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import asdict
 from datetime import datetime, timezone
 from typing import Any
+import uuid
 
 from flask import Blueprint, abort, jsonify, request, url_for
 
@@ -66,7 +67,7 @@ def _validate_durations(duration_min: int, duration_raw_min: int) -> None:
 
 
 def _task_from_json(data: dict[str, Any]) -> Task:
-    required = {"id", "title", "category", "duration_min", "duration_raw_min", "priority"}
+    required = {"title", "category", "duration_min", "duration_raw_min", "priority"}
     missing = required - data.keys()
     if missing:
         _problem(422, "invalid-field", f"Missing field(s): {', '.join(sorted(missing))}")
@@ -110,6 +111,7 @@ def list_tasks():
 @bp.post("")
 def create_task():
     data = request.get_json(force=True, silent=False)
+    data["id"] = str(uuid.uuid4())
     task = _task_from_json(data)
     TASKS[task.id] = task
 

--- a/tests/integration/test_tasks.py
+++ b/tests/integration/test_tasks.py
@@ -36,7 +36,6 @@ def test_list_empty(client) -> None:
 
 def test_create_and_get(client) -> None:
     payload = {
-        "id": "1",
         "title": "Task",
         "category": "general",
         "duration_min": 20,
@@ -47,7 +46,7 @@ def test_create_and_get(client) -> None:
     resp = client.post("/api/tasks", json=payload)
     assert resp.status_code == 201
     data = resp.get_json()
-    assert data["id"] == "1"
+    assert "id" in data
     assert data["earliest_start_utc"] == "2025-01-01T09:00:00Z"
 
     resp = client.get("/api/tasks")
@@ -56,7 +55,6 @@ def test_create_and_get(client) -> None:
 
 def test_validation_error(client) -> None:
     payload = {
-        "id": "x",
         "title": "bad",
         "category": "g",
         "duration_min": 21,
@@ -70,7 +68,6 @@ def test_validation_error(client) -> None:
 
 def test_invalid_priority(client) -> None:
     payload = {
-        "id": "p",
         "title": "badprio",
         "category": "g",
         "duration_min": 10,
@@ -90,21 +87,21 @@ def test_update_not_found(client) -> None:
 
 def test_update_and_delete(client) -> None:
     payload = {
-        "id": "2",
         "title": "T",
         "category": "c",
         "duration_min": 10,
         "duration_raw_min": 10,
         "priority": "B",
     }
-    client.post("/api/tasks", json=payload)
+    resp = client.post("/api/tasks", json=payload)
+    task_id = resp.get_json()["id"]
 
     upd = payload | {"title": "Updated"}
-    resp = client.put("/api/tasks/2", json=upd)
+    resp = client.put(f"/api/tasks/{task_id}", json=upd)
     assert resp.status_code == 200
     assert resp.get_json()["title"] == "Updated"
 
-    del_resp = client.delete("/api/tasks/2")
+    del_resp = client.delete(f"/api/tasks/{task_id}")
     assert del_resp.status_code == 204
 
     resp = client.get("/api/tasks")


### PR DESCRIPTION
## Summary
- generate UUID4 IDs when creating tasks
- make `id` optional for `_task_from_json`
- update integration tests to expect generated IDs

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_6862806dfde0832dbeb26de517283910