### PR TITLE
Adjust duration validation

### DIFF
--- a/schedule_app/api/tasks.py
+++ b/schedule_app/api/tasks.py
@@ -54,14 +54,14 @@ def _validate_durations(duration_min: int, duration_raw_min: int) -> None:
         and isinstance(duration_raw_min, int)
         and duration_min > 0
         and duration_raw_min > 0
-        and duration_min % 10 == 0
+        and duration_min % 5 == 0
         and duration_raw_min % 5 == 0
     )
     if not ok:
         _problem(
             422,
             "invalid-field",
-            "Duration must be positive; raw multiple of 5, rounded multiple of 10.",
+            "Duration must be a positive multiple of 5 minutes.",
         )
 
 

--- a/tests/integration/test_tasks.py
+++ b/tests/integration/test_tasks.py
@@ -65,7 +65,9 @@ def test_validation_error(client) -> None:
     }
     resp = client.post("/api/tasks", json=payload)
     assert resp.status_code == 422
-    _assert_problem_details(resp.get_json())
+    data = resp.get_json()
+    _assert_problem_details(data)
+    assert data["detail"] == "Duration must be a positive multiple of 5 minutes."
 
 
 def test_invalid_priority(client) -> None:


### PR DESCRIPTION
## Summary
- relax `duration_min` check to allow multiples of 5 minutes per spec
- ensure error message is consistent with §6
- update integration test to assert the new error detail

## Testing
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_6862806f7434832d98110cf97987257e