### PR TITLE
Fix missing blocks API registration

### DIFF
--- a/schedule_app/__init__.py
+++ b/schedule_app/__init__.py
@@ -83,12 +83,15 @@ def create_app(*, testing: bool = False) -> Flask:  # type: ignore[name-defined]
         app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
 
     from schedule_app.api import calendar_bp, tasks_bp
+    from schedule_app.api.blocks import init_app as init_blocks_api
 
     if calendar_bp is not None:
         app.register_blueprint(calendar_bp)
 
     if tasks_bp is not None:
         app.register_blueprint(tasks_bp)
+
+    init_blocks_api(app)
 
     # ヘルスチェック用エンドポイント
     @app.get("/api/health")


### PR DESCRIPTION
## Summary
- register blocks API blueprint during app creation

## Testing
- `pytest tests/integration/test_blocks.py -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_68632be5de04832da38d50ff7943f2b1