### PR TITLE
Move blocks API into package

### DIFF
--- a/schedule_app/__init__.py
+++ b/schedule_app/__init__.py
@@ -83,12 +83,16 @@ def create_app(*, testing: bool = False) -> Flask:  # type: ignore[name-defined]
         app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
 
     from schedule_app.api import calendar_bp, tasks_bp
+    from schedule_app.api.blocks import init_blocks_api
 
     if calendar_bp is not None:
         app.register_blueprint(calendar_bp)
 
     if tasks_bp is not None:
         app.register_blueprint(tasks_bp)
+
+    # blocks API
+    init_blocks_api(app)
 
     # ヘルスチェック用エンドポイント
     @app.get("/api/health")

--- a/schedule_app/api/blocks.py
+++ b/schedule_app/api/blocks.py
@@ -5,9 +5,9 @@ Block CRUD REST API  (/api/blocks …)
     - schedule_app.models.Block  (UTC 保持の dataclass)
     - Flask 2.3
 設置:
-    from schedule_app.api.blocks import init_app
+    from schedule_app.api.blocks import init_blocks_api
     app = Flask(__name__)
-    init_app(app)
+    init_blocks_api(app)
 """
 
 from __future__ import annotations
@@ -22,7 +22,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 
 from schedule_app.models import Block
 
-__all__ = ["blocks_bp", "init_app"]
+__all__ = ["blocks_bp", "init_blocks_api"]
 
 
 # --------------------------------------------------------------------------- #
@@ -139,6 +139,6 @@ def delete_block(id_: str) -> Response:
 # --------------------------------------------------------------------------- #
 # blueprint 登録用ファサード
 # --------------------------------------------------------------------------- #
-def init_app(app) -> None:  # noqa: ANN001
+def init_blocks_api(app) -> None:  # noqa: ANN001
     """Factory Pattern で呼ばれる。アプリに Blueprint を取り付ける。"""
     app.register_blueprint(blocks_bp)


### PR DESCRIPTION
## Summary
- move API blueprint for blocks under the package
- hook up `init_blocks_api` in `create_app`

## Testing
- `pytest -q tests/integration/test_blocks.py` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_68632e51bf60832d82dccaa535033f87