### PR TITLE
Add schedule API blueprint and tests

### DIFF
--- a/schedule_app/__init__.py
+++ b/schedule_app/__init__.py
@@ -82,7 +82,7 @@ def create_app(*, testing: bool = False) -> Flask:  # type: ignore[name-defined]
     if testing:
         app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
 
-    from schedule_app.api import calendar_bp, tasks_bp
+    from schedule_app.api import calendar_bp, tasks_bp, schedule_bp
     from schedule_app.api.blocks import init_blocks_api
 
     if calendar_bp is not None:
@@ -90,6 +90,9 @@ def create_app(*, testing: bool = False) -> Flask:  # type: ignore[name-defined]
 
     if tasks_bp is not None:
         app.register_blueprint(tasks_bp)
+
+    if schedule_bp is not None:
+        app.register_blueprint(schedule_bp)
 
     # blocks API
     init_blocks_api(app)

--- a/schedule_app/api/__init__.py
+++ b/schedule_app/api/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 # Explicitly export optional blueprints
-__all__ = ["calendar_bp", "tasks_bp"]
+__all__ = ["calendar_bp", "tasks_bp", "schedule_bp"]
 
 try:
     from .calendar import calendar_bp  # type: ignore
@@ -14,3 +14,8 @@ try:
     from .tasks import bp as tasks_bp  # type: ignore
 except Exception:  # pragma: no cover - optional blueprint
     tasks_bp = None  # type: ignore
+
+try:
+    from .schedule import bp as schedule_bp  # type: ignore
+except Exception:  # pragma: no cover - optional blueprint
+    schedule_bp = None  # type: ignore

--- a/schedule_app/api/schedule.py
+++ b/schedule_app/api/schedule.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from flask import Blueprint, abort, jsonify, request
+from werkzeug.exceptions import BadRequest
+
+from schedule_app.models import Block, Event
+from schedule_app.services import schedule
+from schedule_app.api.tasks import _task_from_json
+from schedule_app.api.blocks import _parse_iso8601
+
+bp = Blueprint("schedule", __name__, url_prefix="/api/schedule")
+schedule_bp = bp
+
+
+def _event_from_json(data: dict[str, Any]) -> Event:
+    try:
+        start = _parse_iso8601(data.get("start_utc"), "start_utc")
+        end = _parse_iso8601(data.get("end_utc"), "end_utc")
+    except BadRequest as exc:  # reuse validation from blocks API
+        resp = jsonify(exc.description)
+        resp.status_code = 422
+        resp.mimetype = "application/problem+json"
+        abort(resp)
+    return Event(
+        id=data.get("id", ""),
+        start_utc=start,
+        end_utc=end,
+        title=data.get("title", ""),
+        all_day=bool(data.get("all_day", False)),
+    )
+
+
+def _block_from_json(data: dict[str, Any]) -> Block:
+    try:
+        start = _parse_iso8601(data.get("start_utc"), "start_utc")
+        end = _parse_iso8601(data.get("end_utc"), "end_utc")
+    except BadRequest as exc:
+        resp = jsonify(exc.description)
+        resp.status_code = 422
+        resp.mimetype = "application/problem+json"
+        abort(resp)
+    return Block(id=data.get("id", ""), start_utc=start, end_utc=end)
+
+
+@bp.post("/generate")
+def generate_schedule():  # noqa: D401 - simple endpoint
+    """Generate a schedule grid for the specified date."""
+    date_str = request.args.get("date")
+    if not date_str:
+        abort(400, description="date parameter required")
+    try:
+        date_obj = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    except ValueError:
+        abort(400, description="invalid date format")
+
+    algo = request.args.get("algo", "greedy")
+    if algo not in {"greedy", "compact"}:
+        abort(400, description="invalid algo")
+
+    payload = request.get_json(silent=True) or {}
+    tasks = [_task_from_json(t) for t in payload.get("tasks", [])]
+    events = [_event_from_json(e) for e in payload.get("events", [])]
+    blocks = [_block_from_json(b) for b in payload.get("blocks", [])]
+
+    grid = schedule.generate(
+        date_utc=date_obj,
+        tasks=tasks,
+        events=events,
+        blocks=blocks,
+        algorithm=algo,  # type: ignore[arg-type]
+    )
+    return jsonify({"slots": grid}), 200
+
+
+__all__ = ["bp", "schedule_bp"]

--- a/tests/integration/test_schedule_api.py
+++ b/tests/integration/test_schedule_api.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+from flask import Flask
+
+from schedule_app import create_app
+
+
+@pytest.fixture()
+def app() -> Flask:
+    return create_app(testing=True)
+
+
+@pytest.fixture()
+def client(app: Flask):
+    return app.test_client()
+
+
+def test_generate_simple(client) -> None:
+    payload = {
+        "tasks": [
+            {
+                "id": "t1",
+                "title": "T1",
+                "category": "gen",
+                "duration_min": 10,
+                "duration_raw_min": 10,
+                "priority": "A",
+            }
+        ],
+        "events": [],
+        "blocks": [],
+    }
+    resp = client.post("/api/schedule/generate?date=2025-01-01", json=payload)
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, dict)
+    assert len(data.get("slots", [])) == 144


### PR DESCRIPTION
## Summary
- implement `schedule_app/api/schedule.py` blueprint
- expose `schedule_bp` via `schedule_app/api/__init__.py`
- register blueprint in the application factory
- add integration test for the schedule API

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686337622a30832d9ba3941c96b61fbe