### PR TITLE
Add schedule API tests

### DIFF
--- a/schedule_app/__init__.py
+++ b/schedule_app/__init__.py
@@ -83,6 +83,7 @@ def create_app(*, testing: bool = False) -> Flask:  # type: ignore[name-defined]
         app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
 
     from schedule_app.api import calendar_bp, tasks_bp
+    from schedule_app.api.schedule import schedule_bp
     from schedule_app.api.blocks import init_blocks_api
 
     if calendar_bp is not None:
@@ -90,6 +91,8 @@ def create_app(*, testing: bool = False) -> Flask:  # type: ignore[name-defined]
 
     if tasks_bp is not None:
         app.register_blueprint(tasks_bp)
+
+    app.register_blueprint(schedule_bp)
 
     # blocks API
     init_blocks_api(app)

--- a/schedule_app/api/__init__.py
+++ b/schedule_app/api/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 # Explicitly export optional blueprints
-__all__ = ["calendar_bp", "tasks_bp"]
+__all__ = ["calendar_bp", "tasks_bp", "schedule_bp"]
 
 try:
     from .calendar import calendar_bp  # type: ignore
@@ -14,3 +14,8 @@ try:
     from .tasks import bp as tasks_bp  # type: ignore
 except Exception:  # pragma: no cover - optional blueprint
     tasks_bp = None  # type: ignore
+
+try:
+    from .schedule import schedule_bp  # type: ignore
+except Exception:  # pragma: no cover - optional blueprint
+    schedule_bp = None  # type: ignore

--- a/schedule_app/api/schedule.py
+++ b/schedule_app/api/schedule.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from flask import Blueprint, abort, current_app, jsonify, request
+
+from schedule_app.services.schedule import generate as generate_schedule
+from schedule_app.api.tasks import TASKS
+from schedule_app.api.blocks import BLOCKS
+
+bp = Blueprint("schedule", __name__, url_prefix="/api/schedule")
+
+
+@bp.post("/generate")
+def generate():
+    date_str = request.args.get("date")
+    if not date_str:
+        abort(400, description="date parameter required")
+    try:
+        date_obj = datetime.strptime(date_str, "%Y-%m-%d")
+    except ValueError:
+        abort(400, description="invalid date format")
+
+    algo = request.args.get("algo", "greedy")
+    if algo not in {"greedy", "compact"}:
+        abort(400, description="invalid algo")
+
+    client = current_app.extensions.get("gclient")
+    events = []
+    if client is not None:
+        events = client.list_events(date=date_obj)
+
+    tasks = list(TASKS.values())
+    blocks = list(BLOCKS.values())
+
+    grid = generate_schedule(
+        date_utc=date_obj,
+        tasks=tasks,
+        events=events,
+        blocks=blocks,
+        algorithm=algo,  # type: ignore[arg-type]
+    )
+    return jsonify(grid), 200
+
+
+schedule_bp = bp
+__all__ = ["schedule_bp"]

--- a/tests/integration/test_schedule_api.py
+++ b/tests/integration/test_schedule_api.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+import pytest
+from flask import Flask
+
+from schedule_app import create_app
+from schedule_app.api.tasks import TASKS
+from schedule_app.api.blocks import BLOCKS
+
+
+class DummyGClient:
+    def list_events(self, *, date: datetime):
+        return []
+
+
+@pytest.fixture()
+def app() -> Flask:
+    flask_app = create_app(testing=True)
+    return flask_app
+
+
+@pytest.fixture()
+def client(app: Flask):
+    TASKS.clear()
+    BLOCKS.clear()
+    return app.test_client()
+
+
+def test_generate_success(app: Flask, client) -> None:
+    app.extensions["gclient"] = DummyGClient()
+    resp = client.post("/api/schedule/generate?date=2025-01-01")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 144
+
+
+def test_generate_missing_date(app: Flask, client) -> None:
+    app.extensions["gclient"] = DummyGClient()
+    resp = client.post("/api/schedule/generate")
+    assert resp.status_code == 400
+    data = json.loads(resp.data)
+    assert data["status"] == 400
+
+
+def test_generate_invalid_date(app: Flask, client) -> None:
+    app.extensions["gclient"] = DummyGClient()
+    resp = client.post("/api/schedule/generate?date=2025/01/01")
+    assert resp.status_code == 400
+    data = json.loads(resp.data)
+    assert data["status"] == 400
+
+
+def test_generate_invalid_algo(app: Flask, client) -> None:
+    app.extensions["gclient"] = DummyGClient()
+    resp = client.post("/api/schedule/generate?date=2025-01-01&algo=bad")
+    assert resp.status_code == 400
+    data = json.loads(resp.data)
+    assert data["status"] == 400


### PR DESCRIPTION
## Summary
- add minimal schedule generation blueprint
- register the blueprint in the app factory
- export blueprint from API package
- write integration tests for schedule generation API

## Testing
- `pytest -q tests/integration/test_schedule_api.py` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_68633765e18c832dbf316f7d6547ed64