### PR TITLE
Add README section for schedule generation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,14 @@ Simple in-memory endpoints used by the front-end.
 | DELETE | `/api/tasks/<id>` | Remove a task |
 
 All datetimes are UTC RFC 3339 strings. Validation errors return a 422 response with type `https://schedule.app/errors/invalid-field`.
+
+## Schedule API
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| POST | `/api/schedule/generate` | Generate a schedule grid for one day |
+
+`date` is a required query parameter in `YYYY-MM-DD` format. `algo` is optional and may be `greedy` (default) or `compact`.
+
+On success, the endpoint returns `200 OK` with JSON like `{"slots": [...]}` containing 144 ten-minute entries. Missing or malformed query parameters yield `400 Bad Request`. Invalid task, event or block data returns a `422` problem response.
+


### PR DESCRIPTION
## Summary
- document the `/api/schedule/generate` endpoint and parameters in README

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_68633ab9a990832d92a9aaf704bddde0