### PR TITLE
Switch API to new schedule helper

### DIFF
--- a/schedule_app/api/schedule.py
+++ b/schedule_app/api/schedule.py
@@ -1,48 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any
-
 from flask import Blueprint, abort, jsonify, request
-from werkzeug.exceptions import BadRequest
 
-from schedule_app.models import Block, Event
 from schedule_app.services import schedule
-from schedule_app.api.tasks import _task_from_json
-from schedule_app.api.blocks import _parse_iso8601
+
 
 bp = Blueprint("schedule", __name__, url_prefix="/api/schedule")
 schedule_bp = bp
-
-
-def _event_from_json(data: dict[str, Any]) -> Event:
-    try:
-        start = _parse_iso8601(data.get("start_utc"), "start_utc")
-        end = _parse_iso8601(data.get("end_utc"), "end_utc")
-    except BadRequest as exc:  # reuse validation from blocks API
-        resp = jsonify(exc.description)
-        resp.status_code = 422
-        resp.mimetype = "application/problem+json"
-        abort(resp)
-    return Event(
-        id=data.get("id", ""),
-        start_utc=start,
-        end_utc=end,
-        title=data.get("title", ""),
-        all_day=bool(data.get("all_day", False)),
-    )
-
-
-def _block_from_json(data: dict[str, Any]) -> Block:
-    try:
-        start = _parse_iso8601(data.get("start_utc"), "start_utc")
-        end = _parse_iso8601(data.get("end_utc"), "end_utc")
-    except BadRequest as exc:
-        resp = jsonify(exc.description)
-        resp.status_code = 422
-        resp.mimetype = "application/problem+json"
-        abort(resp)
-    return Block(id=data.get("id", ""), start_utc=start, end_utc=end)
 
 
 @bp.post("/generate")
@@ -60,19 +25,8 @@ def generate_schedule():  # noqa: D401 - simple endpoint
     if algo not in {"greedy", "compact"}:
         abort(400, description="invalid algo")
 
-    payload = request.get_json(silent=True) or {}
-    tasks = [_task_from_json(t) for t in payload.get("tasks", [])]
-    events = [_event_from_json(e) for e in payload.get("events", [])]
-    blocks = [_block_from_json(b) for b in payload.get("blocks", [])]
-
-    grid = schedule.generate(
-        date_utc=date_obj,
-        tasks=tasks,
-        events=events,
-        blocks=blocks,
-        algorithm=algo,  # type: ignore[arg-type]
-    )
-    return jsonify({"slots": grid}), 200
+    result = schedule.generate_schedule(date_obj.date(), algo=algo)
+    return jsonify(result), 200
 
 
 __all__ = ["bp", "schedule_bp"]

--- a/tests/integration/test_schedule_api.py
+++ b/tests/integration/test_schedule_api.py
@@ -17,22 +17,10 @@ def client(app: Flask):
 
 
 def test_generate_simple(client) -> None:
-    payload = {
-        "tasks": [
-            {
-                "id": "t1",
-                "title": "T1",
-                "category": "gen",
-                "duration_min": 10,
-                "duration_raw_min": 10,
-                "priority": "A",
-            }
-        ],
-        "events": [],
-        "blocks": [],
-    }
-    resp = client.post("/api/schedule/generate?date=2025-01-01", json=payload)
+    resp = client.post("/api/schedule/generate?date=2025-01-01")
     assert resp.status_code == 200
     data = resp.get_json()
     assert isinstance(data, dict)
-    assert len(data.get("slots", [])) == 144
+    assert set(data.keys()) == {"date", "algo", "slots", "unplaced"}
+    assert data["date"] == "2025-01-01"
+    assert len(data["slots"]) == 144

--- a/tests/unit/test_schedule.py
+++ b/tests/unit/test_schedule.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone, date
 
 from freezegun import freeze_time
 
-from schedule_app.models import Event, Task
+from schedule_app.models import Task, Block
 from schedule_app.services import schedule
+from schedule_app.api.tasks import TASKS
+from schedule_app.api.blocks import BLOCKS
 
 
 def _dt(iso: str) -> datetime:
@@ -14,39 +16,9 @@ def _dt(iso: str) -> datetime:
 
 @freeze_time("2025-01-01T00:00:00Z")
 def test_priority_order() -> None:
-    tasks = [
-        Task(
-            id="A1",
-            title="",
-            category="",
-            duration_min=30,
-            duration_raw_min=30,
-            priority="A",
-        ),
-        Task(
-            id="B1",
-            title="",
-            category="",
-            duration_min=30,
-            duration_raw_min=30,
-            priority="B",
-        ),
-    ]
-    grid = schedule.generate(date_utc=_dt("2025-01-01T00:00:00Z"), tasks=tasks, events=[], blocks=[])
-    assert len(grid) == 144
-    assert grid[:3] == ["A1"] * 3
-    assert grid[3:6] == ["B1"] * 3
-
-
-@freeze_time("2025-01-01T00:00:00Z")
-def test_busy_slot() -> None:
-    event = Event(
-        id="e1",
-        start_utc=_dt("2025-01-01T00:00:00Z"),
-        end_utc=_dt("2025-01-01T01:00:00Z"),
-        title="busy",
-    )
-    task = Task(
+    TASKS.clear()
+    BLOCKS.clear()
+    TASKS["A1"] = Task(
         id="A1",
         title="",
         category="",
@@ -54,15 +26,50 @@ def test_busy_slot() -> None:
         duration_raw_min=30,
         priority="A",
     )
-    grid = schedule.generate(date_utc=_dt("2025-01-01T00:00:00Z"), tasks=[task], events=[event], blocks=[])
-    assert len(grid) == 144
-    assert all(slot is None for slot in grid[:6])
-    assert grid[6:9] == ["A1"] * 3
+    TASKS["B1"] = Task(
+        id="B1",
+        title="",
+        category="",
+        duration_min=30,
+        duration_raw_min=30,
+        priority="B",
+    )
+
+    result = schedule.generate_schedule(date(2025, 1, 1))
+    slots = result["slots"]
+    assert len(slots) == 144
+    assert slots[:6] == [2] * 6
+
+
+@freeze_time("2025-01-01T00:00:00Z")
+def test_busy_slot() -> None:
+    TASKS.clear()
+    BLOCKS.clear()
+    BLOCKS["b1"] = Block(
+        id="b1",
+        start_utc=_dt("2025-01-01T00:00:00Z"),
+        end_utc=_dt("2025-01-01T01:00:00Z"),
+    )
+    TASKS["A1"] = Task(
+        id="A1",
+        title="",
+        category="",
+        duration_min=30,
+        duration_raw_min=30,
+        priority="A",
+    )
+    result = schedule.generate_schedule(date(2025, 1, 1))
+    slots = result["slots"]
+    assert len(slots) == 144
+    assert slots[:6] == [1] * 6
+    assert slots[6:9] == [2] * 3
 
 
 @freeze_time("2025-01-01T00:00:00Z")
 def test_earliest_start() -> None:
-    task = Task(
+    TASKS.clear()
+    BLOCKS.clear()
+    TASKS["A1"] = Task(
         id="A1",
         title="",
         category="",
@@ -71,8 +78,9 @@ def test_earliest_start() -> None:
         priority="A",
         earliest_start_utc=_dt("2025-01-01T12:00:00Z"),
     )
-    grid = schedule.generate(date_utc=_dt("2025-01-01T00:00:00Z"), tasks=[task], events=[], blocks=[])
-    assert len(grid) == 144
-    assert all(slot is None for slot in grid[:72])
-    assert grid[72:75] == ["A1"] * 3
+    result = schedule.generate_schedule(date(2025, 1, 1))
+    slots = result["slots"]
+    assert len(slots) == 144
+    assert all(s == 0 for s in slots[:72])
+    assert slots[72:75] == [2] * 3
 


### PR DESCRIPTION
## Summary
- call `generate_schedule` in schedule endpoint
- adjust unit tests for the new helper output
- update integration test expectations

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686347569f84832d9379614079584dbd