### PR TITLE
Enable coverage gating in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,5 @@ jobs:
 
       - run: python -m pip install -r requirements.dev.txt
       - run: ruff check .
-      - run: pytest -q
+      - run: pytest
+        # addopts で --cov と閾値が自動付加される

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+addopts = "-q --cov=schedule_app --cov-report=term-missing --cov-fail-under=80"
+testpaths = ["tests"]

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -10,3 +10,4 @@ playwright==1.*
 pre-commit==3.*
 pip-audit==2.*
 google-auth-oauthlib>=1.2.0
+pytest-cov>=5.0


### PR DESCRIPTION
## Summary
- require pytest-cov and set coverage options in `pyproject.toml`
- adjust CI to use pytest directly
- add `pytest-cov` to dev dependencies

## Testing
- `ruff check .`
- `pytest` *(fails: `freezegun` missing due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68634e7796a4832d97b306fbcc2e8d3a