### PR TITLE
Add frontend script and static path

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -1,0 +1,11 @@
+export async function loadEvents() {
+  const resp = await fetch('/api/health');
+  const data = await resp.json();
+  const el = document.getElementById('events');
+  if (el) {
+    el.textContent = data.status;
+  }
+}
+
+// load immediately when module is imported
+loadEvents();

--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -5,5 +5,7 @@
 </head>
 <body>
 <h1>Hello</h1>
+<div id="events"></div>
+<script type="module" src="/static/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add simple JS module that loads from `/api/health`
- display events div in `index.html` and load the module

## Testing
- `pytest -q` *(fails: freezegun is required)*
- `pre-commit run --files schedule_app/templates/index.html schedule_app/static/js/app.js` *(fails: pre-commit not found)*
- `flask --app schedule_app run -p 5001` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686352345a20832dad642661f2da47da