### PR TITLE
Initialize GoogleClient in app factory

### DIFF
--- a/schedule_app/__init__.py
+++ b/schedule_app/__init__.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import os
 from werkzeug.exceptions import HTTPException
 
+from schedule_app.services.google_client import GoogleClient
+
 try:  # Flask may be absent in some test environments
     from flask import Flask  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
@@ -78,6 +80,9 @@ def create_app(*, testing: bool = False) -> Flask:  # type: ignore[name-defined]
 
     app = Flask(__name__)
     app.secret_key = "dev-secret-key"
+
+    # Lightweight Google API client stub
+    app.extensions["gclient"] = GoogleClient(credentials=None)
 
     if testing:
         app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)

--- a/tests/unit/test_create_app_gclient.py
+++ b/tests/unit/test_create_app_gclient.py
@@ -1,0 +1,8 @@
+from schedule_app import create_app
+from schedule_app.services.google_client import GoogleClient
+
+
+def test_create_app_has_google_client_extension():
+    app = create_app(testing=True)
+    assert "gclient" in app.extensions
+    assert isinstance(app.extensions["gclient"], GoogleClient)


### PR DESCRIPTION
## Summary
- import `GoogleClient` in the package init
- create and store a `GoogleClient` instance in `create_app`
- test that `create_app()` exposes the client via `app.extensions`

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686359c7f0fc832d94b4db412d56b8d8