### PR TITLE
Add Event dataclass parsing

### DIFF
--- a/tests/unit/test_google_client_list.py
+++ b/tests/unit/test_google_client_list.py
@@ -1,5 +1,6 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
+from schedule_app.models import Event
 from schedule_app.services.google_client import GoogleClient
 
 
@@ -19,5 +20,30 @@ def test_list_events_range(monkeypatch):
 
     assert captured["time_min"] == "2025-01-01T00:00:00Z"
     assert captured["time_max"] == "2025-01-02T00:00:00Z"
+
+
+def test_list_events_dataclass(monkeypatch):
+    client = GoogleClient(credentials=None)
+
+    sample = {
+        "id": "1",
+        "summary": "Demo",
+        "start": {"dateTime": "2025-01-01T01:00:00Z"},
+        "end": {"dateTime": "2025-01-01T02:00:00Z"},
+    }
+
+    def fake_fetch(*, time_min: str, time_max: str):
+        return [sample]
+
+    monkeypatch.setattr(client, "fetch_calendar_events", fake_fetch)
+
+    events = client.list_events(date=datetime(2025, 1, 1))
+    assert len(events) == 1
+    ev = events[0]
+    assert isinstance(ev, Event)
+    assert ev.id == "1"
+    assert ev.title == "Demo"
+    assert ev.start_utc == datetime(2025, 1, 1, 1, 0, tzinfo=timezone.utc)
+    assert ev.end_utc == datetime(2025, 1, 1, 2, 0, tzinfo=timezone.utc)
 
 


### PR DESCRIPTION
## Summary
- parse Google Calendar API results into `Event` dataclasses
- expose parsed objects from `GoogleClient.list_events`
- extend unit tests for dataclass output

## Testing
- `ruff check schedule_app/services/google_client.py tests/unit/test_google_client_list.py`
- `pip install -r requirements.dev.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: freezegun is required to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_686359c9fe64832d96968a67e981edc7