### PR TITLE
Add stub events for missing Google creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ pip install -r requirements.dev.txt  # includes freezegun
 pytest -q
 ```
 
+## Google Calendar Stub
+
+When the application runs without OAuth credentials, the `GoogleClient`
+automatically returns two dummy events at 09:00 and 13:00 for the requested
+day. This allows the `/api/calendar` endpoint and tests to work without real
+Google access.
+
 
 ## Tasks API
 

--- a/tests/integration/test_calendar.py
+++ b/tests/integration/test_calendar.py
@@ -11,6 +11,7 @@ from flask import Flask
 from schedule_app import create_app
 from schedule_app.api.calendar import HttpError, RefreshError
 from schedule_app.models import Event
+from schedule_app.services.google_client import GoogleClient
 
 
 class DummyGClient:
@@ -96,3 +97,14 @@ def test_calendar_forbidden(app: Flask, client) -> None:
     assert resp.status_code == 403
     data = json.loads(resp.data)
     _assert_problem_details(data)
+
+
+@freeze_time("2025-01-01T00:00:00Z")
+def test_calendar_stub_events(app: Flask, client) -> None:
+    app.extensions["gclient"] = GoogleClient(credentials=None)
+    resp = client.get("/api/calendar?date=2025-01-01")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 2
+

--- a/tests/unit/test_google_client_list.py
+++ b/tests/unit/test_google_client_list.py
@@ -1,10 +1,10 @@
 from datetime import datetime
 
-from schedule_app.services.google_client import GoogleClient
+from schedule_app.services.google_client import GoogleClient, Event
 
 
 def test_list_events_range(monkeypatch):
-    client = GoogleClient(credentials=None)
+    client = GoogleClient(credentials="dummy")
 
     captured = {}
 
@@ -19,5 +19,13 @@ def test_list_events_range(monkeypatch):
 
     assert captured["time_min"] == "2025-01-01T00:00:00Z"
     assert captured["time_max"] == "2025-01-02T00:00:00Z"
+
+
+def test_list_events_returns_dummy_when_no_creds():
+    client = GoogleClient(credentials=None)
+    events = client.list_events(date=datetime(2025, 1, 1))
+    assert len(events) == 2
+    assert isinstance(events[0], Event)
+
 
 


### PR DESCRIPTION
## Summary
- return dummy events when Google credentials are absent
- cover this behaviour with unit & integration tests
- document stub behaviour in README

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686359ca89a0832d9e0266a93bd04d78