### PR TITLE
docs: show gclient stub setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,12 @@ On success, the endpoint returns `200 OK` with a **ScheduleGrid** object:
 Missing or malformed query parameters yield `400 Bad Request`. Invalid task,
 event or block data returns a `422` problem response.
 
+
+## Google Calendar Stub
+
+```python
+from schedule_app.services.google_client import GoogleClient
+
+app.extensions["gclient"] = GoogleClient(credentials=None)
+```
+


### PR DESCRIPTION
## Summary
- document how to create a `GoogleClient` and store it in `app.extensions["gclient"]`

## Testing
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_68635da98ae8832daeed8e82f38917fc