### PR TITLE
Add Ruff cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .venv/
 venv/
 __pycache__/
+.ruff_cache/
 *.py[cod]
 *.pyo
 # 環境変数ファイル


### PR DESCRIPTION
## Summary
- ignore `.ruff_cache/` in `.gitignore`

## Testing
- `pre-commit run --files .gitignore` *(fails: command not found)*
- `pytest -q` *(fails: missing dependency `freezegun`)*

------
https://chatgpt.com/codex/tasks/task_e_68635da9bfa8832d93adb215ff286054