### PR TITLE
Update API spec with 502 notes

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -110,7 +110,7 @@ class Block:
 
 | Method | Path                                                            | 成功           | 失敗                          |
 | ------ | --------------------------------------------------------------- | ------------ | --------------------------- |
-| GET    | `/api/calendar?date={2025-01-01T09:00:00+09:00\|YYYY‑MM‑DD}`                                 | 200 Event\[] | 400 / 401 / 403 / 404 / 500 |
+| GET    | `/api/calendar?date={2025-01-01T09:00:00+09:00\|YYYY‑MM‑DD}`                        | 200 Event\[] | 400 / 401 / 403 / 404 / 500 / 502 |
 | GET    | `/api/tasks`                                                    | 200 Task\[]  | –                           |
 | POST   | `/api/tasks`                                                    | 201 Task     | 422 invalid‑field           |
 | PUT    | `/api/tasks/{id}`                                               | 200 Task     | 404 / 422                   |
@@ -122,6 +122,7 @@ class Block:
 | POST   | `/api/schedule/generate?date=YYYY‑MM‑DD&algo={greedy\|compact}` | 200 Grid     | 400 / 422                   |
 
 *`date` は ISO‑8601 日時 (例: `2025-01-01T09:00:00+09:00`) または `YYYY‑MM‑DD` を受け付け、値は `list_events` 呼び出し前に UTC へ正規化される。*
+*Upstream failures are surfaced as 502 Bad Gateway.*
 *Problem Details 例*
 
 ```json


### PR DESCRIPTION
## Summary
- document upstream failure handling
- list `502` as a possible `/api/calendar` error code

## Testing
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_68636bddabf8832d9151dcf21d81e338