### PR TITLE
Add keyboard focus for slots

### DIFF
--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -19,9 +19,9 @@
                   {% if m != '00' %}opacity-0{% endif %}">
         {{ h }}:{{ m }}
       </div>
-      <div class="slot border-b border-gray-200 hover:bg-blue-50
-                  cursor-pointer"
-           data-slot="{{ i }}"></div>
+      <div class="slot border-b border-gray-200 hover:bg-blue-50 cursor-pointer
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+           role="listitem" tabindex="0" data-slot="{{ i }}"></div>
     {% endfor %}
   </section>
 </main>


### PR DESCRIPTION
## Summary
- add `role="listitem"` and `tabindex="0"` to grid slots
- apply Tailwind focus-visible ring styles for keyboard users

## Testing
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_6863830c57d8832dad74ea7efae0cfd7