### PR TITLE
Add Playwright tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,8 @@ jobs:
       - run: ruff check .
       - run: pytest
         # addopts で --cov と閾値が自動付加される
+      - name: Run Playwright tests
+        run: |
+          npm ci
+          npx playwright install --with-deps
+          npx playwright test


### PR DESCRIPTION
## Summary
- update `.github/workflows/ci.yml` to run Playwright tests after pytest

## Testing
- `ruff check .`
- `pytest -q` *(fails: `freezegun` not installed)*
- `npm ci` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6863889c91b4832da0e9b1df8298134a