### PR TITLE
Add Node setup to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
           cache-dependency-path: |
             requirements.dev.txt
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
       - run: python -m pip install -r requirements.dev.txt
       - run: ruff check .
       - run: pytest


### PR DESCRIPTION
## Summary
- setup Node using `actions/setup-node@v4` in CI

## Testing
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_68638b3d913c832d83b85131b516b506