### PR TITLE
Add Playwright tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,16 @@ jobs:
       - run: ruff check .
       - run: pytest
         # addopts で --cov と閾値が自動付加される
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: npx playwright test


### PR DESCRIPTION
## Summary
- run Playwright tests in the CI workflow

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest` *(fails: freezegun is required)*
- `npx playwright test` *(fails: cannot reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_68638b291e18832da6adfdf1b9870a5b