### PR TITLE
Add Playwright tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,11 @@ jobs:
         with:
           node-version: lts/*
 
+      - run: npm ci
+      - run: npx playwright install --with-deps
+
       - run: python -m pip install -r requirements.dev.txt
       - run: ruff check .
       - run: pytest
         # addopts で --cov と閾値が自動付加される
+      - run: npx playwright test


### PR DESCRIPTION
## Summary
- run Playwright tests in CI by installing npm deps and browsers

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun is required)*
- `npm ci` *(fails: network access needed)*
- `npx playwright test` *(fails: network access needed)*
- `pre-commit run --files .github/workflows/ci.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686394d54a5c832db5a22956794fbfd2