### PR TITLE
Add task pane and fetch logic

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -104,6 +104,46 @@ export const openDb = (() => {
 // Kick off immediately so the DB appears in DevTools without user action
 window.dbReady = openDb();
 
+/* ─────────────────── 既存コードの下 (DnD 即上あたり) ────────────────── */
+//////////////////////////////////////////////////////////////////////
+//  SECTION: Task loading / rendering
+//////////////////////////////////////////////////////////////////////
+
+async function loadAndRenderTasks() {
+  try {
+    const res   = await fetch('/api/tasks');
+    const tasks = await res.json();          // [{id,title,…}, …]
+
+    const pane       = document.getElementById('task-pane');
+    const emptyLabel = document.getElementById('task-empty');
+    pane.querySelectorAll('.task-card').forEach((n) => n.remove());
+
+    if (!tasks.length) {
+      emptyLabel.classList.remove('hidden');
+      return;
+    }
+    emptyLabel.classList.add('hidden');
+
+    for (const t of tasks) {
+      const card = document.createElement('div');
+      card.className =
+        'task-card p-2 bg-white rounded shadow border ' +
+        'cursor-grab select-none hover:bg-gray-50';
+      card.setAttribute('draggable', 'true');
+      card.dataset.taskId = t.id;
+      card.textContent    = `${t.title} (${t.duration_min}m)`;
+      pane.appendChild(card);
+    }
+  } catch (err) {
+    console.error('[tasks] failed to load', err);
+  }
+}
+
+/* DOMContentLoaded → まずタスクを描画 */
+document.addEventListener('DOMContentLoaded', () => {
+  loadAndRenderTasks();
+});
+
 /* ────────────────────────────────────────────────────────────────
  *  Drag & Drop support for task cards ⇄ time‑grid slots
  *  Spec §8.1  “.dragging → opacity:0.5”  /  drop target ring‑blue‑400

--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -4,13 +4,22 @@
 <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
 </head>
 <body>
-<main class="p-4">
-  <h1>Hello</h1>
+<main class="p-4 flex gap-4">
+  <!-- ── task side-pane ───────────────────────────────────────────── -->
+  <aside id="task-pane"
+         class="w-60 shrink-0 border-r border-gray-300 pr-4 space-y-2 overflow-y-auto"
+         aria-label="Tasks list">
+    <!-- JS がここに .task-card を挿入 -->
+    <p id="task-empty" class="text-gray-500 text-sm">タスクがありません</p>
+  </aside>
+
+  <!-- ── time grid ─────────────────────────────────────────────────── -->
+  <h1 class="sr-only">Day schedule</h1>
   <div id="events"></div>
   <section id="time-grid"
            role="list"
            aria-label="24-hour schedule grid"
-           class="grid border border-gray-300 grid-cols-[70px_1fr]">
+           class="grid border border-gray-300 grid-cols-[70px_1fr] flex-1">
     {% for i in range(144) %}
       {% set ts = (i * 10) %}
       {% set h = '{:02d}'.format(ts // 60) %}


### PR DESCRIPTION
## Summary
- add a side pane for tasks in `index.html`
- fetch tasks from `/api/tasks` and render draggable cards

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_6863c7a88610832db5c29d742f89437c