### PR TITLE
Add header undo/redo buttons with JS logic

### DIFF
--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -4,6 +4,24 @@
 <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
 </head>
 <body>
+<header class="sticky top-0 bg-white p-2 shadow flex items-center gap-3">
+  <!-- Undo / Redo Buttons -->
+  <div id="history-buttons" class="inline-flex items-center gap-1 mr-2">
+    <button
+      id="undo-btn"
+      title="元に戻す (Ctrl+Z)"
+      class="px-2 py-1 rounded border text-gray-400 border-gray-300"
+      disabled
+    >←</button>
+    <button
+      id="redo-btn"
+      title="やり直す (Ctrl+Y)"
+      class="px-2 py-1 rounded border text-gray-400 border-gray-300"
+      disabled
+    >→</button>
+  </div>
+  <button id="generate-btn" class="px-3 py-1 rounded border border-blue-600 bg-blue-600 text-white">Generate ▶</button>
+</header>
 <main class="p-4 flex gap-4">
   <!-- ── task side-pane ───────────────────────────────────────────── -->
   <aside id="task-pane"


### PR DESCRIPTION
## Summary
- create sticky header with Generate button and undo/redo controls
- hook up undo/redo buttons in app.js
- update history functions to refresh button states

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_6864ce57f8d8832d829493585e904dbc