### PR TITLE
Handle Google API errors

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -20,9 +20,12 @@
   /** Event[] を取得 */
   async function fetchEvents(dateStr) {
     const res = await fetch(`/api/calendar?date=${dateStr}`);
-    if (!res.ok) {
-      throw new Error(`Calendar API failed: ${res.status}`);
+    if (res.status === 401) {
+      // 資格情報失効。サインイン画面へ遷移
+      window.location.href = '/login';
+      return [];
     }
+    if (!res.ok) throw new Error(`Calendar API failed: ${res.status}`);
     return res.json(); // [{ id, title, ... }]
   }
 

--- a/tests/integration/test_calendar.py
+++ b/tests/integration/test_calendar.py
@@ -10,7 +10,11 @@ from freezegun import freeze_time
 from flask import Flask
 
 from schedule_app import create_app
-from schedule_app.services.google_client import APIError
+from schedule_app.services.google_client import (
+    GoogleAPITransient,
+    GoogleAPIUnauthorized,
+    APIError,
+)
 from schedule_app.models import Event
 
 
@@ -81,18 +85,24 @@ def test_calendar_success(app: Flask, client) -> None:
 
 @freeze_time("2025-01-01T00:00:00Z")
 def test_calendar_unauthorized(app: Flask, client) -> None:
-    with patch("schedule_app.api.calendar.GoogleClient", return_value=DummyGClient(raise_exc=APIError("unauthorized"))):
+    with patch(
+        "schedule_app.api.calendar.GoogleClient",
+        return_value=DummyGClient(raise_exc=GoogleAPIUnauthorized()),
+    ):
         with client.session_transaction() as sess:
             sess["credentials"] = {"access_token": "tok", "expiry": None}
         resp = client.get("/api/calendar?date=2025-01-01")
-    assert resp.status_code == 502
+    assert resp.status_code == 401
     data = json.loads(resp.data)
     _assert_problem_details(data)
 
 
 @freeze_time("2025-01-01T00:00:00Z")
-def test_calendar_forbidden(app: Flask, client) -> None:
-    with patch("schedule_app.api.calendar.GoogleClient", return_value=DummyGClient(raise_exc=APIError("forbidden"))):
+def test_calendar_transient(app: Flask, client) -> None:
+    with patch(
+        "schedule_app.api.calendar.GoogleClient",
+        return_value=DummyGClient(raise_exc=GoogleAPITransient()),
+    ):
         with client.session_transaction() as sess:
             sess["credentials"] = {"access_token": "tok", "expiry": None}
         resp = client.get("/api/calendar?date=2025-01-01")


### PR DESCRIPTION
## Summary
- add specific Google API error classes and raise them
- surface Google API Unauthorized and transient errors in API layer
- redirect to `/login` from frontend when receiving HTTP 401
- update calendar API tests for new behaviours

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864da707d5c832da1efa6bce61e384a