### PR TITLE
Centralize APIError

### DIFF
--- a/schedule_app/exceptions.py
+++ b/schedule_app/exceptions.py
@@ -1,5 +1,9 @@
 class APIError(Exception):
-    """Raised when an upstream API request fails."""
+    """Raised when an upstream API request fails.
+
+    This is used for token errors or other issues communicating
+    with external services.
+    """
 
     def __init__(self, description: str) -> None:
         self.description = description

--- a/schedule_app/services/google_client.py
+++ b/schedule_app/services/google_client.py
@@ -15,12 +15,7 @@ import json
 from datetime import datetime, timedelta, timezone
 
 from schedule_app.models import Event
-
-
-class APIError(Exception):
-    """Raised when token is missing or unauthorized."""
-
-
+from schedule_app.exceptions import APIError
 
 
 # OAuth scopes required for accessing Google APIs


### PR DESCRIPTION
## Summary
- consolidate APIError definition under `schedule_app.exceptions`
- import and re-export APIError from `google_client`

## Testing
- `npm --version`
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_6864de8bba04832d8dcfc5f135f5d1d4