### PR TITLE
Add calendar _problem helper

### DIFF
--- a/schedule_app/api/calendar.py
+++ b/schedule_app/api/calendar.py
@@ -1,17 +1,38 @@
 from __future__ import annotations
 
 from datetime import datetime
+from http import HTTPStatus
 from dataclasses import asdict
 
 from schedule_app.models import Event
 
-from flask import Blueprint, request, session, abort, jsonify
+from flask import Blueprint, request, session, jsonify
 
 from schedule_app.services.google_client import GoogleClient, APIError
 
 
 bp = Blueprint("calendar_bp", __name__)
 calendar_bp = bp
+
+
+def _problem(status: int, code: str, detail: str):
+    """Return a JSON Problem response."""
+    try:
+        title = HTTPStatus(status).phrase
+    except Exception:
+        title = "Error"
+    response = jsonify(
+        {
+            "type": f"https://schedule.app/errors/{code}",
+            "title": title,
+            "status": status,
+            "detail": detail,
+            "instance": request.path,
+        }
+    )
+    response.status_code = status
+    response.mimetype = "application/problem+json"
+    return response
 
 
 def _event_to_dict(ev: Event) -> dict:
@@ -25,22 +46,22 @@ def _event_to_dict(ev: Event) -> dict:
 def get_calendar():
     date_str = request.args.get("date")
     if not date_str:
-        abort(400, "missing date")
+        return _problem(400, "bad-request", "missing date")
 
     try:
         date_obj = datetime.fromisoformat(date_str)
     except ValueError:
-        abort(400, "invalid date")
+        return _problem(400, "bad-request", "invalid date")
 
     creds = session.get("credentials")
     if not creds:
-        abort(401)
+        return _problem(401, "unauthorized", "missing credentials")
 
     client = GoogleClient(creds)
     try:
         events = client.list_events(date=date_obj)
     except APIError as e:
-        abort(502, f"google_api: {e}")
+        return _problem(502, "bad-gateway", f"google_api: {e}")
 
     return jsonify([_event_to_dict(e) for e in events]), 200
 


### PR DESCRIPTION
## Summary
- create `_problem` in calendar API
- return `_problem(...)` instead of `abort`

## Testing
- `ruff check schedule_app/api/calendar.py`
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_6864e3c6063c832d807989dbf3c14c4d