### PR TITLE
Add E2E test for dynamic time grid

### DIFF
--- a/schedule_app/static/test/minimal.html
+++ b/schedule_app/static/test/minimal.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Minimal</title>
+  <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+</head>
+<body>
+  <div id="history-buttons">
+    <button id="undo-btn" disabled>←</button>
+    <button id="redo-btn" disabled>→</button>
+  </div>
+  <button id="generate-btn">Generate ▶</button>
+  <div id="task-pane">
+    <p id="task-empty">No tasks</p>
+  </div>
+  <div id="events"></div>
+  <!-- #time-grid will be injected by app.js -->
+  <script type="module" src="/static/js/app.js"></script>
+</body>
+</html>

--- a/tests/e2e/dynamic_time_grid.spec.ts
+++ b/tests/e2e/dynamic_time_grid.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test('app.js injects time grid when missing', async ({ page }) => {
+  // Mock API endpoints to prevent network errors
+  await page.route('**/api/**', route => {
+    route.fulfill({ status: 200, body: '[]', contentType: 'application/json' });
+  });
+
+  await page.goto('/static/test/minimal.html');
+
+  const grid = page.locator('#time-grid');
+  await expect(grid).toBeVisible();
+  await expect(grid.locator('.slot')).toHaveCount(144);
+});


### PR DESCRIPTION
## Summary
- add a minimal HTML fixture without `#time-grid`
- test that `/static/js/app.js` inserts a 144-slot grid when loaded

## Testing
- `npx playwright test tests/e2e/dynamic_time_grid.spec.ts --reporter=line --timeout=30000` *(fails: npm access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6864e3c83538832db4d2136d6a46022e