### PR TITLE
Add GoogleAPIUnauthorized exception

### DIFF
--- a/schedule_app/services/google_client.py
+++ b/schedule_app/services/google_client.py
@@ -18,6 +18,13 @@ from schedule_app.models import Event
 from schedule_app.exceptions import APIError
 
 
+class GoogleAPIUnauthorized(APIError):
+    """Raised when Google API calls are unauthorized."""
+
+    def __init__(self, description: str = "unauthorized") -> None:
+        super().__init__(description)
+
+
 # OAuth scopes required for accessing Google APIs
 
 SCOPES = [
@@ -140,4 +147,4 @@ class GoogleClient:
         return [self._to_event(item) for item in items]
 
 
-__all__ = ["GoogleClient", "APIError", "SCOPES"]
+__all__ = ["GoogleClient", "GoogleAPIUnauthorized", "APIError", "SCOPES"]


### PR DESCRIPTION
## Summary
- extend the Google client to include a new `GoogleAPIUnauthorized` subclass of `APIError`
- export the new exception in `__all__`

## Testing
- `ruff check`
- `pytest -q` *(fails: freezegun is required to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_6864e7312bcc832d96ae03ba7fa2ae89