### PR TITLE
Handle unauthorized Google API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ event or block data returns a `422` problem response.
 
 ## Calendar API
 
-`GET /api/calendar` returns Google events for the given day. When stored
-credentials have expired, the endpoint responds with **401 Unauthorized** and
+`GET /api/calendar` returns Google events for the given day. If credentials are
+missing, expired or revoked, the endpoint responds with **401 Unauthorized** and
 provides instructions in the JSON body to re-authenticate via `/login`.
 
 The front-end will automatically build the `#time-grid` element at page load if

--- a/SPEC.md
+++ b/SPEC.md
@@ -123,6 +123,7 @@ class Block:
 
 *`date` は ISO‑8601 日時 (例: `2025-01-01T09:00:00+09:00`) または `YYYY‑MM‑DD` を受け付け、値は `list_events` 呼び出し前に UTC へ正規化される。*
 *Google Calendar API が失敗した場合は 502 Bad Gateway として応答する。*
+*認証情報が欠如・期限切れ・取り消しの場合は 401 Unauthorized を返す。*
 *Problem Details 例*
 
 ```json

--- a/schedule_app/api/calendar.py
+++ b/schedule_app/api/calendar.py
@@ -8,7 +8,11 @@ from schedule_app.models import Event
 
 from flask import Blueprint, request, session, jsonify
 
-from schedule_app.services.google_client import GoogleClient, APIError
+from schedule_app.services.google_client import (
+    GoogleClient,
+    APIError,
+    GoogleAPIUnauthorized,
+)
 
 
 bp = Blueprint("calendar_bp", __name__)
@@ -60,6 +64,8 @@ def get_calendar():
     client = GoogleClient(creds)
     try:
         events = client.list_events(date=date_obj)
+    except GoogleAPIUnauthorized as e:
+        return _problem(401, "unauthorized", str(e))
     except APIError as e:
         return _problem(502, "bad-gateway", f"google_api: {e}")
 

--- a/schedule_app/services/google_client.py
+++ b/schedule_app/services/google_client.py
@@ -90,7 +90,7 @@ class GoogleClient:
                 data = json.loads(resp.read().decode())
         except HTTPError as e:  # pragma: no cover - network stubbed
             if e.code in (401, 403):
-                raise APIError("unauthorized") from e
+                raise GoogleAPIUnauthorized() from e
             raise
         return data.get("items", [])
 

--- a/tests/integration/test_calendar.py
+++ b/tests/integration/test_calendar.py
@@ -10,7 +10,7 @@ from freezegun import freeze_time
 from flask import Flask
 
 from schedule_app import create_app
-from schedule_app.services.google_client import APIError
+from schedule_app.services.google_client import APIError, GoogleAPIUnauthorized
 from schedule_app.models import Event
 
 
@@ -90,11 +90,14 @@ def test_calendar_success(app: Flask, client) -> None:
 
 @freeze_time("2025-01-01T00:00:00Z")
 def test_calendar_unauthorized(app: Flask, client) -> None:
-    with patch("schedule_app.api.calendar.GoogleClient", return_value=DummyGClient(raise_exc=APIError("unauthorized"))):
+    with patch(
+        "schedule_app.api.calendar.GoogleClient",
+        return_value=DummyGClient(raise_exc=GoogleAPIUnauthorized()),
+    ):
         with client.session_transaction() as sess:
             sess["credentials"] = {"access_token": "tok", "expiry": None}
         resp = client.get("/api/calendar?date=2025-01-01")
-    assert resp.status_code == 502
+    assert resp.status_code == 401
     data = json.loads(resp.data)
     _assert_problem_details(data)
 

--- a/tests/unit/test_google_client_fetch.py
+++ b/tests/unit/test_google_client_fetch.py
@@ -1,0 +1,21 @@
+import pytest
+from urllib.error import HTTPError
+
+from schedule_app.services.google_client import GoogleClient, GoogleAPIUnauthorized
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_fetch_unauthorized(monkeypatch, status):
+    client = GoogleClient(credentials={"access_token": "tok"})
+
+    def raise_error(req):  # pragma: no cover - stub
+        raise HTTPError(req.full_url, status, "", {}, None)
+
+    monkeypatch.setattr("schedule_app.services.google_client.request.urlopen", raise_error)
+
+    with pytest.raises(GoogleAPIUnauthorized):
+        client.fetch_calendar_events(
+            time_min="2025-01-01T00:00:00Z",
+            time_max="2025-01-02T00:00:00Z",
+        )
+


### PR DESCRIPTION
## Summary
- raise `GoogleAPIUnauthorized` when Google Calendar API returns 401 or 403
- surface unauthorized errors from the Calendar endpoint as 401
- test calendar endpoint with unauthorized errors
- verify `fetch_calendar_events` raises the new exception
- document 401 responses in README and SPEC

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_6864eae5e650832da285c71a068dd4b2