### PR TITLE
Implement schedule grid generator

### DIFF
--- a/schedule_app/api/schedule.py
+++ b/schedule_app/api/schedule.py
@@ -25,7 +25,7 @@ def generate_schedule():  # noqa: D401 - simple endpoint
     if algo not in {"greedy", "compact"}:
         abort(400, description="invalid algo")
 
-    result = schedule.generate_schedule(date_obj.date(), algo=algo)
+    result = schedule.generate_schedule_dict(date_obj.date(), algo=algo)
     return jsonify(result), 200
 
 

--- a/schedule_app/services/schedule.py
+++ b/schedule_app/services/schedule.py
@@ -159,10 +159,12 @@ def generate_schedule_dict(date: date, *, algo: str = "greedy") -> dict:
 
 
 def generate_schedule(
-    *,
     target_day: date,
+    *,
     algo: str = "greedy",
     events: list[Event] | None = None,
+    tasks: list[Task] | None = None,
+    blocks: list[Block] | None = None,
 ) -> list[int]:
     """Return a busy/free grid for ``target_day`` based on ``events``."""
 

--- a/tests/unit/test_schedule_grid.py
+++ b/tests/unit/test_schedule_grid.py
@@ -1,0 +1,26 @@
+from datetime import datetime, timezone, timedelta
+
+from schedule_app.models import Event
+from schedule_app.services.schedule import generate_schedule
+
+
+def test_event_jst_mapped_to_correct_utc_slot():
+    # 14:30 JST -> 05:30 UTC
+    start = datetime(2025, 7, 2, 14, 30, tzinfo=timezone(timedelta(hours=9)))
+    end = datetime(2025, 7, 2, 15, 30, tzinfo=timezone(timedelta(hours=9)))
+
+    grid = generate_schedule(
+        target_day=datetime(2025, 7, 2, tzinfo=timezone.utc).date(),
+        algo="greedy",
+        events=[
+            Event(
+                id="x",
+                title="\u30c6\u30b9\u30c8",
+                start_utc=start.astimezone(timezone.utc),
+                end_utc=end.astimezone(timezone.utc),
+            )
+        ],
+    )
+
+    busy_idx = [i for i, s in enumerate(grid) if s == 1]
+    assert busy_idx == list(range(33, 39))


### PR DESCRIPTION
## Summary
- add new `generate_schedule` for event-based grids
- keep old JSON API generator as `generate_schedule_dict`
- update API to use renamed function
- add unit test for JST to UTC grid mapping

## Testing
- `pytest -q tests/unit/test_schedule_grid.py` *(fails: Skipped: freezegun is required to run tests)*
- `pytest -q` *(fails: Skipped: freezegun is required to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_686506a3f874832dabe457185d51c1be