### PR TITLE
Simplify schedule output

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,13 @@ On success, the endpoint returns `200 OK` with a **ScheduleGrid** object:
 ```json
 {
   "date": "2025-01-01",
-  "algo": "greedy",
-  "slots": [0, 1, 2, ...],
-  "unplaced": ["task-id"]
+  "slots": ["task-id", null, ...]
 }
 ```
 
-`slots` is an array of 144 ten-minute entries where `0` means free, `1` busy and
-`2` occupied by a task. `unplaced` lists task IDs that could not be scheduled.
+`slots` is an array of 144 ten-minute entries containing task IDs or `null` if
+the slot is free. The scheduling algorithm used is indicated by the `algo`
+query parameter.
 Missing or malformed query parameters yield `400 Bad Request`. Invalid task,
 event or block data returns a `422` problem response.
 

--- a/schedule_app/services/schedule.py
+++ b/schedule_app/services/schedule.py
@@ -113,6 +113,8 @@ def generate(
 def generate_schedule(date: date, *, algo: str = "greedy") -> dict:
     """Return a simple JSON friendly schedule for ``date``.
 
+    Returns dict with keys ``date`` and ``slots``.
+
     Parameters
     ----------
     date:
@@ -125,7 +127,8 @@ def generate_schedule(date: date, *, algo: str = "greedy") -> dict:
     from schedule_app.api.tasks import TASKS
     from schedule_app.api.blocks import BLOCKS
 
-    base = datetime.combine(date, datetime.min.time(), tzinfo=timezone.utc)
+    target_day = date
+    base = datetime.combine(target_day, datetime.min.time(), tzinfo=timezone.utc)
 
     tasks = list(TASKS.values())
     blocks = list(BLOCKS.values())
@@ -138,21 +141,7 @@ def generate_schedule(date: date, *, algo: str = "greedy") -> dict:
         algorithm=algo,
     )
 
-    busy_map = _init_slot_map(base, [], blocks)
-
-    slots: list[int] = []
-    for idx, cell in enumerate(grid):
-        if cell is None:
-            slots.append(1 if busy_map[idx] else 0)
-        else:
-            slots.append(2)
-
-    placed_ids = {t_id for t_id in grid if t_id is not None}
-    unplaced = [t.id for t in tasks if t.id not in placed_ids]
-
     return {
-        "date": date.isoformat(),
-        "algo": algo,
-        "slots": slots,
-        "unplaced": unplaced,
+        "date": target_day.isoformat(),
+        "slots": grid,
     }

--- a/tests/integration/test_schedule_api.py
+++ b/tests/integration/test_schedule_api.py
@@ -21,6 +21,6 @@ def test_generate_simple(client) -> None:
     assert resp.status_code == 200
     data = resp.get_json()
     assert isinstance(data, dict)
-    assert set(data.keys()) == {"date", "algo", "slots", "unplaced"}
+    assert set(data.keys()) == {"date", "slots"}
     assert data["date"] == "2025-01-01"
     assert len(data["slots"]) == 144

--- a/tests/unit/test_generate_schedule.py
+++ b/tests/unit/test_generate_schedule.py
@@ -11,5 +11,4 @@ def test_generate_schedule_empty() -> None:
     result = generate_schedule(date(2025, 1, 1), algo="greedy")
     assert result["date"] == "2025-01-01"
     assert len(result["slots"]) == 144
-    assert result["slots"] == [0] * 144
-    assert result["unplaced"] == []
+    assert result["slots"] == [None] * 144

--- a/tests/unit/test_schedule.py
+++ b/tests/unit/test_schedule.py
@@ -38,7 +38,8 @@ def test_priority_order() -> None:
     result = schedule.generate_schedule(date(2025, 1, 1))
     slots = result["slots"]
     assert len(slots) == 144
-    assert slots[:6] == [2] * 6
+    assert slots[:3] == ["A1"] * 3
+    assert slots[3:6] == ["B1"] * 3
 
 
 @freeze_time("2025-01-01T00:00:00Z")
@@ -61,8 +62,8 @@ def test_busy_slot() -> None:
     result = schedule.generate_schedule(date(2025, 1, 1))
     slots = result["slots"]
     assert len(slots) == 144
-    assert slots[:6] == [1] * 6
-    assert slots[6:9] == [2] * 3
+    assert slots[:6] == [None] * 6
+    assert slots[6:9] == ["A1"] * 3
 
 
 @freeze_time("2025-01-01T00:00:00Z")
@@ -81,6 +82,6 @@ def test_earliest_start() -> None:
     result = schedule.generate_schedule(date(2025, 1, 1))
     slots = result["slots"]
     assert len(slots) == 144
-    assert all(s == 0 for s in slots[:72])
-    assert slots[72:75] == [2] * 3
+    assert all(s is None for s in slots[:72])
+    assert slots[72:75] == ["A1"] * 3
 


### PR DESCRIPTION
## Summary
- return slots grid directly from `generate_schedule`
- clarify docstring about return values
- update unit tests for new schedule output

## Testing
- `ruff check .`
- `pytest -q` *(fails: Skipped: freezegun is required to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_68651062a5c8832d97d3d276f292598b