### PR TITLE
Update schedule tests

### DIFF
--- a/tests/integration/test_schedule_api.py
+++ b/tests/integration/test_schedule_api.py
@@ -20,7 +20,5 @@ def test_generate_simple(client) -> None:
     resp = client.post("/api/schedule/generate?date=2025-01-01")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert isinstance(data, dict)
-    assert set(data.keys()) == {"date", "algo", "slots", "unplaced"}
-    assert data["date"] == "2025-01-01"
-    assert len(data["slots"]) == 144
+    assert isinstance(data, list)
+    assert len(data) == 144

--- a/tests/unit/test_schedule_grid.py
+++ b/tests/unit/test_schedule_grid.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from datetime import date
+
+from freezegun import freeze_time
+
+from schedule_app.services.schedule import generate_schedule
+from schedule_app.api.tasks import TASKS
+from schedule_app.api.blocks import BLOCKS
+
+
+@freeze_time("2025-01-01T00:00:00Z")
+def test_access_grid_via_slots() -> None:
+    TASKS.clear()
+    BLOCKS.clear()
+    result = generate_schedule(date(2025, 1, 1))
+    grid = result["slots"]
+    assert isinstance(grid, list)
+    assert len(grid) == 144
+    assert grid == [0] * 144


### PR DESCRIPTION
## Summary
- add unit test to verify generate_schedule returns grid via `slots`
- adjust schedule API integration test to expect list response

## Testing
- `pytest -q` *(fails: freezegun not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686510681b20832da3123961438ca468