### PR TITLE
Update docs for schedule endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,21 +57,18 @@ All datetimes are UTC RFC 3339 strings. Validation errors return a 422 response 
 `date` is a required query parameter in `YYYY-MM-DD` format. `algo` is optional
 and may be `greedy` (default) or `compact`.
 
-On success, the endpoint returns `200 OK` with a **ScheduleGrid** object:
+On success, the endpoint returns `200 OK` with just the `slots` array:
 
 ```json
-{
-  "date": "2025-01-01",
-  "algo": "greedy",
-  "slots": [0, 1, 2, ...],
-  "unplaced": ["task-id"]
-}
+[0, 1, 2, ...]
 ```
 
 `slots` is an array of 144 ten-minute entries where `0` means free, `1` busy and
-`2` occupied by a task. `unplaced` lists task IDs that could not be scheduled.
-Missing or malformed query parameters yield `400 Bad Request`. Invalid task,
-event or block data returns a `422` problem response.
+`2` occupied by a task. The underlying `schedule.generate_schedule()` service
+function still returns a dictionary with `date`, `algo`, `slots` and `unplaced`
+for use in other parts of the application. Missing or malformed query
+parameters yield `400 Bad Request`. Invalid task, event or block data returns a
+`422` problem response.
 
 ## Calendar API
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -119,11 +119,12 @@ class Block:
 | POST   | `/api/blocks`                                                   | 201 Block    | 422                         |
 | PUT    | `/api/blocks/{id}`                                              | 200 Block    | 404 / 422                   |
 | DELETE | `/api/blocks/{id}`                                              | 204          | 404                         |
-| POST   | `/api/schedule/generate?date=YYYY‑MM‑DD&algo={greedy\|compact}` | 200 Grid     | 400 / 422                   |
+| POST   | `/api/schedule/generate?date=YYYY‑MM‑DD&algo={greedy\|compact}` | 200 Slot[]   | 400 / 422                   |
 
 *`date` は ISO‑8601 日時 (例: `2025-01-01T09:00:00+09:00`) または `YYYY‑MM‑DD` を受け付け、値は `list_events` 呼び出し前に UTC へ正規化される。*
 *Google Calendar API が失敗した場合は 502 Bad Gateway として応答する。*
 *認証情報が欠如・期限切れ・取り消しの場合は 401 Unauthorized を返す。*
+*サービス層の `generate_schedule()` は `date`・`algo`・`slots`・`unplaced` を含む辞書を返す。*
 *Problem Details 例*
 
 ```json


### PR DESCRIPTION
## Summary
- clarify that `/api/schedule/generate` returns only the slots array
- note that the service function still yields a dictionary

## Testing
- `pytest -q` *(fails: freezegun not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68651068975c832dab745deb852131b3