### PR TITLE
Refactor generate_schedule to remove unused parameter

### DIFF
--- a/schedule_app/api/schedule.py
+++ b/schedule_app/api/schedule.py
@@ -25,7 +25,8 @@ def generate_schedule():  # noqa: D401 - simple endpoint
     if algo not in {"greedy", "compact"}:
         abort(400, description="invalid algo")
 
-    result = schedule.generate_schedule(date_obj.date(), algo=algo)
+    # TODO: support algorithm variations
+    result = schedule.generate_schedule(date_obj.date())
     return jsonify(result), 200
 
 

--- a/schedule_app/services/schedule.py
+++ b/schedule_app/services/schedule.py
@@ -110,16 +110,15 @@ def generate(
     return grid
 
 
-def generate_schedule(date: date, *, algo: str = "greedy") -> dict:
+def generate_schedule(date: date) -> dict:
     """Return a simple JSON friendly schedule for ``date``.
 
     Parameters
     ----------
     date:
         Target day in UTC.
-    algo:
-        Scheduling algorithm to use. Only ``"greedy"`` or ``"compact"`` are
-        currently supported.
+
+    TODO: allow selecting algorithm (greedy/compact) once implemented.
     """
 
     from schedule_app.api.tasks import TASKS
@@ -135,7 +134,6 @@ def generate_schedule(date: date, *, algo: str = "greedy") -> dict:
         tasks=tasks,
         events=[],
         blocks=blocks,
-        algorithm=algo,
     )
 
     busy_map = _init_slot_map(base, [], blocks)
@@ -152,7 +150,6 @@ def generate_schedule(date: date, *, algo: str = "greedy") -> dict:
 
     return {
         "date": date.isoformat(),
-        "algo": algo,
         "slots": slots,
         "unplaced": unplaced,
     }

--- a/tests/unit/test_generate_schedule.py
+++ b/tests/unit/test_generate_schedule.py
@@ -8,7 +8,7 @@ from schedule_app.api.blocks import BLOCKS
 def test_generate_schedule_empty() -> None:
     TASKS.clear()
     BLOCKS.clear()
-    result = generate_schedule(date(2025, 1, 1), algo="greedy")
+    result = generate_schedule(date(2025, 1, 1))
     assert result["date"] == "2025-01-01"
     assert len(result["slots"]) == 144
     assert result["slots"] == [0] * 144


### PR DESCRIPTION
## Summary
- remove `algo` parameter from `generate_schedule`
- document future algorithm support
- adjust API endpoint and tests

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865106a60bc832daedd08e82ca9faaa