### PR TITLE
Update schedule API response format

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,19 +57,14 @@ All datetimes are UTC RFC 3339 strings. Validation errors return a 422 response 
 `date` is a required query parameter in `YYYY-MM-DD` format. `algo` is optional
 and may be `greedy` (default) or `compact`.
 
-On success, the endpoint returns `200 OK` with a **ScheduleGrid** object:
+On success, the endpoint returns `200 OK` with a list of 144 slot values:
 
 ```json
-{
-  "date": "2025-01-01",
-  "algo": "greedy",
-  "slots": [0, 1, 2, ...],
-  "unplaced": ["task-id"]
-}
+[0, 1, 2, ...]
 ```
 
-`slots` is an array of 144 ten-minute entries where `0` means free, `1` busy and
-`2` occupied by a task. `unplaced` lists task IDs that could not be scheduled.
+Each entry represents a ten-minute block where `0` means free, `1` busy and
+`2` occupied by a task.
 Missing or malformed query parameters yield `400 Bad Request`. Invalid task,
 event or block data returns a `422` problem response.
 

--- a/schedule_app/api/schedule.py
+++ b/schedule_app/api/schedule.py
@@ -26,7 +26,7 @@ def generate_schedule():  # noqa: D401 - simple endpoint
         abort(400, description="invalid algo")
 
     result = schedule.generate_schedule(date_obj.date(), algo=algo)
-    return jsonify(result), 200
+    return jsonify(result["slots"]), 200
 
 
 __all__ = ["bp", "schedule_bp"]

--- a/tests/integration/test_schedule_api.py
+++ b/tests/integration/test_schedule_api.py
@@ -20,7 +20,5 @@ def test_generate_simple(client) -> None:
     resp = client.post("/api/schedule/generate?date=2025-01-01")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert isinstance(data, dict)
-    assert set(data.keys()) == {"date", "algo", "slots", "unplaced"}
-    assert data["date"] == "2025-01-01"
-    assert len(data["slots"]) == 144
+    assert isinstance(data, list)
+    assert len(data) == 144

--- a/tests/unit/test_schedule_grid.py
+++ b/tests/unit/test_schedule_grid.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from datetime import date
+
+from freezegun import freeze_time
+
+from schedule_app.services.schedule import generate_schedule
+from schedule_app.api.tasks import TASKS
+from schedule_app.api.blocks import BLOCKS
+
+
+@freeze_time("2025-01-01T00:00:00Z")
+def test_access_grid_via_slots() -> None:
+    TASKS.clear()
+    BLOCKS.clear()
+    result = generate_schedule(date(2025, 1, 1))
+    grid = result["slots"]
+    assert isinstance(grid, list)
+    assert len(grid) == 144
+    assert grid == [0] * 144


### PR DESCRIPTION
## Summary
- schedule `/api/schedule/generate` now returns just the slots list
- update README to document simplified API response

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686510681b20832da3123961438ca468