### PR TITLE
Update schedule API test expectations

### DIFF
--- a/schedule_app/api/schedule.py
+++ b/schedule_app/api/schedule.py
@@ -26,7 +26,8 @@ def generate_schedule():  # noqa: D401 - simple endpoint
         abort(400, description="invalid algo")
 
     result = schedule.generate_schedule(date_obj.date(), algo=algo)
-    return jsonify(result["slots"]), 200
+    result.pop("algo", None)
+    return jsonify(result), 200
 
 
 __all__ = ["bp", "schedule_bp"]

--- a/tests/integration/test_schedule_api.py
+++ b/tests/integration/test_schedule_api.py
@@ -20,5 +20,7 @@ def test_generate_simple(client) -> None:
     resp = client.post("/api/schedule/generate?date=2025-01-01")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert isinstance(data, list)
-    assert len(data) == 144
+    assert isinstance(data, dict)
+    assert set(data.keys()) == {"date", "slots", "unplaced"}
+    assert data["date"] == "2025-01-01"
+    assert len(data["slots"]) == 144


### PR DESCRIPTION
## Summary
- expect schedule API to return a dict without `algo`
- adjust endpoint to drop the `algo` key before returning

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686518d03470832d83208694233a4a51