### PR TITLE
Update docs for schedule API

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ All datetimes are UTC RFC 3339 strings. Validation errors return a 422 response 
 | ------ | ---- | ----------- |
 | POST | `/api/schedule/generate` | Generate a schedule grid for one day |
 
-`date` is a required query parameter in `YYYY-MM-DD` format. `algo` is optional
-and may be `greedy` (default) or `compact`.
+`date` is a required query parameter in `YYYY-MM-DD` format.
+<!-- TODO: support selecting different scheduling algorithms -->
 
 On success, the endpoint returns `200 OK` with just the `slots` array:
 
@@ -65,7 +65,7 @@ On success, the endpoint returns `200 OK` with just the `slots` array:
 
 `slots` is an array of 144 ten-minute entries where `0` means free, `1` busy and
 `2` occupied by a task. The underlying `schedule.generate_schedule()` service
-function still returns a dictionary with `date`, `algo`, `slots` and `unplaced`
+function still returns a dictionary with `date`, `slots` and `unplaced`
 for use in other parts of the application. Missing or malformed query
 parameters yield `400 Bad Request`. Invalid task, event or block data returns a
 `422` problem response.

--- a/SPEC.md
+++ b/SPEC.md
@@ -119,7 +119,7 @@ class Block:
 | POST   | `/api/blocks`                                                   | 201 Block    | 422                         |
 | PUT    | `/api/blocks/{id}`                                              | 200 Block    | 404 / 422                   |
 | DELETE | `/api/blocks/{id}`                                              | 204          | 404                         |
-| POST   | `/api/schedule/generate?date=YYYY‑MM‑DD&algo={greedy\|compact}` | 200 Slot[]   | 400 / 422                   |
+| POST   | `/api/schedule/generate?date=YYYY‑MM‑DD` | 200 Slot[]   | 400 / 422                   |
 
 *`date` は ISO‑8601 日時 (例: `2025-01-01T09:00:00+09:00`) または `YYYY‑MM‑DD` を受け付け、値は `list_events` 呼び出し前に UTC へ正規化される。*
 *Google Calendar API が失敗した場合は 502 Bad Gateway として応答する。*


### PR DESCRIPTION
## Summary
- remove algo options from README schedule API section
- add TODO for future algorithm support
- update SPEC docs for schedule API path

## Testing
- `pytest -q` *(fails: freezegun not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686518d289d4832d894553bcd02fff30