### PR TITLE
Rename schedule parameter

### DIFF
--- a/schedule_app/api/schedule.py
+++ b/schedule_app/api/schedule.py
@@ -25,7 +25,7 @@ def generate_schedule():  # noqa: D401 - simple endpoint
     if algo not in {"greedy", "compact"}:
         abort(400, description="invalid algo")
 
-    result = schedule.generate_schedule(date_obj.date(), algo=algo)
+    result = schedule.generate_schedule(target_day=date_obj.date(), algo=algo)
     result.pop("algo", None)
     return jsonify(result), 200
 

--- a/schedule_app/services/schedule.py
+++ b/schedule_app/services/schedule.py
@@ -110,12 +110,12 @@ def generate(
     return grid
 
 
-def generate_schedule(date: date, *, algo: str = "greedy") -> dict:
-    """Return a simple JSON friendly schedule for ``date``.
+def generate_schedule(target_day: date, *, algo: str = "greedy") -> dict:
+    """Return a simple JSON friendly schedule for ``target_day``.
 
     Parameters
     ----------
-    date:
+    target_day:
         Target day in UTC.
     algo:
         Scheduling algorithm to use. Only ``"greedy"`` or ``"compact"`` are
@@ -125,7 +125,7 @@ def generate_schedule(date: date, *, algo: str = "greedy") -> dict:
     from schedule_app.api.tasks import TASKS
     from schedule_app.api.blocks import BLOCKS
 
-    base = datetime.combine(date, datetime.min.time(), tzinfo=timezone.utc)
+    base = datetime.combine(target_day, datetime.min.time(), tzinfo=timezone.utc)
 
     tasks = list(TASKS.values())
     blocks = list(BLOCKS.values())
@@ -151,7 +151,7 @@ def generate_schedule(date: date, *, algo: str = "greedy") -> dict:
     unplaced = [t.id for t in tasks if t.id not in placed_ids]
 
     return {
-        "date": date.isoformat(),
+        "date": target_day.isoformat(),
         "algo": algo,
         "slots": slots,
         "unplaced": unplaced,

--- a/tests/unit/test_generate_schedule.py
+++ b/tests/unit/test_generate_schedule.py
@@ -8,7 +8,7 @@ from schedule_app.api.blocks import BLOCKS
 def test_generate_schedule_empty() -> None:
     TASKS.clear()
     BLOCKS.clear()
-    result = generate_schedule(date(2025, 1, 1), algo="greedy")
+    result = generate_schedule(target_day=date(2025, 1, 1), algo="greedy")
     assert result["date"] == "2025-01-01"
     assert len(result["slots"]) == 144
     assert result["slots"] == [0] * 144

--- a/tests/unit/test_schedule.py
+++ b/tests/unit/test_schedule.py
@@ -35,7 +35,7 @@ def test_priority_order() -> None:
         priority="B",
     )
 
-    result = schedule.generate_schedule(date(2025, 1, 1))
+    result = schedule.generate_schedule(target_day=date(2025, 1, 1))
     slots = result["slots"]
     assert len(slots) == 144
     assert slots[:6] == [2] * 6
@@ -58,7 +58,7 @@ def test_busy_slot() -> None:
         duration_raw_min=30,
         priority="A",
     )
-    result = schedule.generate_schedule(date(2025, 1, 1))
+    result = schedule.generate_schedule(target_day=date(2025, 1, 1))
     slots = result["slots"]
     assert len(slots) == 144
     assert slots[:6] == [1] * 6
@@ -78,7 +78,7 @@ def test_earliest_start() -> None:
         priority="A",
         earliest_start_utc=_dt("2025-01-01T12:00:00Z"),
     )
-    result = schedule.generate_schedule(date(2025, 1, 1))
+    result = schedule.generate_schedule(target_day=date(2025, 1, 1))
     slots = result["slots"]
     assert len(slots) == 144
     assert all(s == 0 for s in slots[:72])


### PR DESCRIPTION
## Summary
- rename `date` parameter to `target_day`
- adjust API call sites
- update tests

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6865254d9ef0832da1224e96739377d9