### PR TITLE
Implement calendar event caching

### DIFF
--- a/schedule_app/services/schedule.py
+++ b/schedule_app/services/schedule.py
@@ -125,7 +125,7 @@ def generate_schedule(target_day: date, *, algo: str = "greedy") -> dict:
     from schedule_app.api.tasks import TASKS
     from schedule_app.api.blocks import BLOCKS
     try:
-        from schedule_app.api.calendar import EVENTS  # in-memory cache
+        from schedule_app.api.calendar import EVENTS  # calendar.py が EVENTS を保持
     except ImportError:
         EVENTS = {}
 


### PR DESCRIPTION
## Summary
- cache Google Calendar events in `schedule_app.api.calendar`
- use cached events when generating schedules
- add helper `to_utc` for timezone conversion
- clarify comment on event cache import

## Testing
- `ruff check schedule_app/api/calendar.py schedule_app/services/schedule.py`
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_68652b836dac832d9dbb4bc324512036