### PR TITLE
Fix schedule API 405 error

### DIFF
--- a/schedule_app/api/schedule.py
+++ b/schedule_app/api/schedule.py
@@ -10,7 +10,7 @@ bp = Blueprint("schedule", __name__, url_prefix="/api/schedule")
 schedule_bp = bp
 
 
-@bp.post("/generate")
+@bp.route("/generate", methods=["POST", "GET"])
 def generate_schedule():  # noqa: D401 - simple endpoint
     """Generate a schedule grid for the specified date."""
     date_str = request.args.get("date")
@@ -27,7 +27,7 @@ def generate_schedule():  # noqa: D401 - simple endpoint
 
     result = schedule.generate_schedule(target_day=date_obj.date(), algo=algo)
     result.pop("algo", None)
-    return jsonify(result), 200
+    return jsonify(result)
 
 
 __all__ = ["bp", "schedule_bp"]

--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -410,7 +410,7 @@ function saveState() {
 /** Load grid data from the server for the given `date`. */
 async function loadGridFromServer(date) {
   const res = await fetch(
-    `/api/schedule/generate?date=${date}`,
+    `/api/schedule/generate?date=${date}&algo=greedy`,
     { method: 'POST' },
   );
 


### PR DESCRIPTION
## Summary
- allow `/api/schedule/generate` to handle GET requests
- always return JSON from the endpoint
- ensure frontend uses POST with `algo=greedy`

## Testing
- `pytest -q` *(fails: freezegun missing)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686537a15bac832db3141f7467f59764