### PR TITLE
Align generate button selector

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -562,9 +562,7 @@ document.addEventListener('DOMContentLoaded', updateUndoRedoButtons);
 // Spec §6, §7 で定義した <div id="time-grid">…</div> を更新する
 // ---------------------------------------------------------------------------
 document.addEventListener('DOMContentLoaded', () => {
-  const btnGenerate =
-    document.querySelector('#btn-generate') ||
-    document.querySelector('#generate-btn');
+  const btnGenerate = document.querySelector('[data-testid="generate-btn"]');
   const inputDate  = document.querySelector('#input-date');
 
   /* ★ 追加 ① — ピッカーがあれば初期値を今日 (UTC) に設定 */

--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -17,6 +17,7 @@
   <!-- Generate ▶ ボタン -->
   <button
     id="btn-generate"
+    data-testid="generate-btn"
     type="button"
     class="inline-flex items-center gap-1 border rounded px-3 py-1
            bg-blue-600 text-white text-sm hover:bg-blue-700 active:translate-y-0.5">


### PR DESCRIPTION
## Summary
- add a `data-testid` to the Generate button
- simplify JS selector to look for `[data-testid]`

## Testing
- `pytest -q` *(fails: freezegun not installed)*
- `npx playwright test` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6865d681b77c832d8ffa6c808999f792