### PR TITLE
Add generate button e2e test

### DIFF
--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -17,6 +17,7 @@
   <!-- Generate ▶ ボタン -->
   <button
     id="btn-generate"
+    data-testid="generate-btn"
     type="button"
     class="inline-flex items-center gap-1 border rounded px-3 py-1
            bg-blue-600 text-white text-sm hover:bg-blue-700 active:translate-y-0.5">

--- a/tests/e2e/generate_button.spec.ts
+++ b/tests/e2e/generate_button.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test('generate button triggers schedule API', async ({ page }) => {
+  // Stub calendar API to avoid 401 redirect during test
+  await page.route('**/api/calendar**', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+
+  await page.goto('http://localhost:5173');
+
+  const [req] = await Promise.all([
+    page.waitForRequest(r => r.url().includes('/api/schedule/generate')),
+    page.getByTestId('generate-btn').click()
+  ]);
+
+  expect(req.method()).toBe('POST');
+});


### PR DESCRIPTION
## Summary
- expose `data-testid="generate-btn"` on the Generate button
- add Playwright spec verifying Generate triggers the schedule API

## Testing
- `pytest -q` *(fails: freezegun required)*
- `npx playwright test` *(fails: network access disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6865d6831628832d87c1c7b34a44d53b