### PR TITLE
Remove old generate-btn query

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -562,9 +562,7 @@ document.addEventListener('DOMContentLoaded', updateUndoRedoButtons);
 // Spec §6, §7 で定義した <div id="time-grid">…</div> を更新する
 // ---------------------------------------------------------------------------
 document.addEventListener('DOMContentLoaded', () => {
-  const btnGenerate =
-    document.querySelector('#btn-generate') ||
-    document.querySelector('#generate-btn');
+  const btnGenerate = document.querySelector('#btn-generate');
   const inputDate  = document.querySelector('#input-date');
 
   /* ★ 追加 ① — ピッカーがあれば初期値を今日 (UTC) に設定 */


### PR DESCRIPTION
## Summary
- use `#btn-generate` consistently

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865d683de80832d821a3f9466c69a78