### PR TITLE
Fix all-day chip focus keyboard support

### DIFF
--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -58,11 +58,15 @@
 
   <!-- クライアント側 JS から clone して使うテンプレート -->
   <template id="tpl-all-day-chip">
-    <li
-      role="listitem"
-      tabindex="0"
-      class="inline-flex items-center rounded-full bg-blue-100 text-blue-800 text-xs font-medium px-3 py-1 whitespace-nowrap focus-visible:ring-2 focus-visible:ring-blue-400"
-    ></li>
+    <li role="listitem" class="inline">
+      <button
+        type="button"
+        class="chip-btn inline-flex items-center rounded-full
+               bg-blue-100 text-blue-800 text-xs font-medium
+               px-3 py-1 whitespace-nowrap
+               focus-visible:ring-2 focus-visible:ring-blue-400"
+      ></button>
+    </li>
   </template>
 </section>
 <!-- ───── End All-day timeline ───── -->
@@ -101,12 +105,20 @@
     // window.renderAllDay(events) が呼ばれる前提。
     // ここでは JS が未実装でもテスト用に global stub を提供しておく。
     window.renderAllDay ??= (events) => {
-      const ul = document.getElementById('all-day-timeline');
+      const ul   = document.getElementById('all-day-timeline');
       const tmpl = document.getElementById('tpl-all-day-chip');
       ul.innerHTML = '';
-      events.forEach(ev => {
-        const li = tmpl.content.firstElementChild.cloneNode(true);
-        li.textContent = ev.title;
+
+      events.forEach((ev) => {
+        const li  = tmpl.content.firstElementChild.cloneNode(true);
+        const btn = li.querySelector('.chip-btn');
+        btn.textContent = ev.title;
+
+        // デモ用クリックハンドラ
+        btn.addEventListener('click', () => {
+          console.log('All\u2011day chip clicked:', ev.id);
+        });
+
         ul.appendChild(li);
       });
     };


### PR DESCRIPTION
## Summary
- refine template for all-day chip by wrapping title in `<button>`
- update `renderAllDay` to populate the `<button>` and log click events

## Testing
- `ruff check .`
- `pytest -q` *(fails: Skipped: freezegun is required to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_6865fd224950832d936c6063a5a7436e