### PR TITLE
Add high contrast focus ring CSS

### DIFF
--- a/schedule_app/static/css/styles.css
+++ b/schedule_app/static/css/styles.css
@@ -1,0 +1,11 @@
+/* High-contrast focus ring */
+:where(:focus-visible) {
+  outline: 2px solid #f90;
+  outline-offset: 2px;
+}
+
+@media (prefers-contrast: more) {
+  :where(:focus-visible) {
+    outline-color: CanvasText;
+  }
+}

--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+<link rel="stylesheet" href="/static/css/styles.css">
 </head>
 <body>
 <header


### PR DESCRIPTION
## Summary
- add stylesheet with high-contrast focus ring rules
- load the stylesheet on the index page

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686609692ef4832da03ea9d14fc03d17