### PR TITLE
Add ARIA roles and focus templates

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -158,8 +158,11 @@ async function loadAndRenderTasks() {
       const card = document.createElement('div');
       card.className =
         'task-card p-2 bg-white rounded shadow border ' +
-        'cursor-grab select-none hover:bg-gray-50';
+        'cursor-grab select-none hover:bg-gray-50 ' +
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400';
       card.setAttribute('draggable', 'true');
+      card.setAttribute('role', 'listitem');
+      card.setAttribute('tabindex', '0');
       card.dataset.taskId = t.id;
       card.dataset.taskTitle = t.title;
       card.textContent    = `${t.title} (${t.duration_min}m)`;
@@ -181,7 +184,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const grid = document.createElement('section');
   grid.id = 'time-grid';
-  grid.setAttribute('role', 'list');
+  grid.setAttribute('role', 'grid');
   grid.setAttribute('aria-label', '24-hour schedule grid');
   grid.className = 'grid border border-gray-300 grid-cols-[70px_1fr] flex-1';
 
@@ -199,7 +202,7 @@ document.addEventListener('DOMContentLoaded', () => {
     slot.className =
       'slot border-b border-gray-200 hover:bg-blue-50 cursor-pointer ' +
       'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400';
-    slot.setAttribute('role', 'listitem');
+    slot.setAttribute('role', 'gridcell');
     slot.setAttribute('tabindex', '0');
     slot.dataset.slotIndex = String(i);
 

--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -74,16 +74,21 @@
   <!-- ── task side-pane ───────────────────────────────────────────── -->
   <aside id="task-pane"
          class="w-60 shrink-0 border-r border-gray-300 pr-4 space-y-2 overflow-y-auto"
-         aria-label="Tasks list">
+         aria-label="Tasks list"
+         role="list">
     <!-- JS がここに .task-card を挿入 -->
     <p id="task-empty" class="text-gray-500 text-sm">タスクがありません</p>
+    <template id="task-card-template">
+      <div class="task-card p-2 bg-white rounded shadow border cursor-grab select-none hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+           role="listitem" tabindex="0" draggable="true"></div>
+    </template>
   </aside>
 
   <!-- ── time grid ─────────────────────────────────────────────────── -->
   <h1 class="sr-only">Day schedule</h1>
   <div id="events"></div>
   <section id="time-grid"
-           role="list"
+           role="grid"
            aria-label="24-hour schedule grid"
            class="grid border border-gray-300 grid-cols-[70px_1fr] flex-1">
     {% for i in range(144) %}
@@ -96,7 +101,7 @@
       </div>
           <div class="slot border-b border-gray-200 hover:bg-blue-50 cursor-pointer
                       focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
-           role="listitem" tabindex="0" data-slot-index="{{ i }}"></div>
+           role="gridcell" tabindex="0" data-slot-index="{{ i }}"></div>
     {% endfor %}
   </section>
 </main>


### PR DESCRIPTION
## Summary
- ensure task-pane is role=list and add task-card template
- switch time grid role from list to grid with gridcell items
- set roles and focus classes for dynamically generated cards and grid cells

## Testing
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_686609694c84832d8e5f170b776382e4