### PR TITLE
Add contrast-sensitive stripe overrides

### DIFF
--- a/schedule_app/static/css/styles.css
+++ b/schedule_app/static/css/styles.css
@@ -56,3 +56,32 @@
   mix-blend-mode: overlay;      /* 下地色とブレンド */
   z-index: 1;                   /* 本体より前面、ドラッグ時は JS 側で上げる */
 }
+
+/* 色覚バリアフリー ― Reduced contrast 専用オーバーライド  */
+@media (prefers-contrast: less) {
+  .task-card::after,
+  .grid-slot--busy::after {
+    /* ブレンドをやめて必ず描く */
+    mix-blend-mode: normal;
+
+    /* 濃度を上げ、背景色に依存しない暗色ストライプ */
+    background-image: repeating-linear-gradient(
+      135deg,
+      rgba(0, 0, 0, 0.22) 0 4px,
+      transparent          4px 8px
+    );
+  }
+}
+
+/* Windows High‑Contrast (forced‑colors) も念のため */
+@media (forced-colors: active) {
+  .task-card::after,
+  .grid-slot--busy::after {
+    background-image: repeating-linear-gradient(
+      135deg,
+      CanvasText 0 4px,
+      transparent 4px 8px
+    );
+    mix-blend-mode: normal;
+  }
+}


### PR DESCRIPTION
## Summary
- support `prefers-contrast: less` by darkening overlay stripes
- ensure stripes remain visible in Windows forced colors mode

## Testing
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_68661ab1a304832d99056bb16906740b