### PR TITLE
Add busy-strong support for reduced contrast

### DIFF
--- a/schedule_app/static/css/styles.css
+++ b/schedule_app/static/css/styles.css
@@ -85,3 +85,15 @@
     mix-blend-mode: normal;
   }
 }
+
+/* === Reduced-contrast 用に濃いストライプだけを切替で適用 === */
+.busy-strong::after {
+  /* 通常モード用ストライプは .task-card::after / .grid-slot--busy::after が既に定義済み */
+  background-image: repeating-linear-gradient(
+    135deg,
+    rgba(0, 0, 0, .24) 0 4px,   /* 黒 24 %：Reduced contrast 時でも消えない */
+    transparent        4px 8px
+  );
+  mix-blend-mode: normal;       /* 背景色に影響されず確実に表示 */
+}
+

--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -629,3 +629,20 @@ function showToast(message) {
   }, 4000);
 }
 
+
+/* === Reduced-contrast 検知 → busy-strong クラス切替 =============== */
+(() => {
+  const mq = window.matchMedia('(prefers-contrast: less)');
+
+  function toggleContrast(e) {
+    const elems = document.querySelectorAll('.grid-slot--busy, .task-card');
+    elems.forEach((el) =>
+      e.matches ? el.classList.add('busy-strong')
+                : el.classList.remove('busy-strong'),
+    );
+  }
+
+  mq.addEventListener('change', toggleContrast);
+  toggleContrast(mq);           // ページ初期表示時に 1 回実行
+})();
+


### PR DESCRIPTION
## Summary
- support darker stripes on busy slots via `.busy-strong` class
- auto-toggle this class when `prefers-contrast: less` is detected

## Testing
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_68667794c5d0832d912b93479fc6a3f1