### PR TITLE
Add print rule to hide task pane

### DIFF
--- a/schedule_app/static/css/print.css
+++ b/schedule_app/static/css/print.css
@@ -20,6 +20,12 @@
   #time-grid {
     --row-h: 6px;
   }
+
+  /* -- Task side-pane も確実に隠す ------------------------ */
+  #task-pane,
+  [id="task-pane"] {
+    display: none !important;
+  }
 }
 
 /* ───────────── 印刷時はストライプを表示しない ───────────── */


### PR DESCRIPTION
## Summary
- hide task side-pane when printing so it's removed from the output

## Testing
- `pytest -q` *(fails: freezegun not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68671979fa7c832db571e159ead631a1