### PR TITLE
Remove unused events container

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -5,7 +5,7 @@
 /**
  * static/js/app.js
  *   ─ 今日の日付を UTC で計算し、/api/calendar から予定一覧を取得。
- *   ─ <div id="events"> にチップ（青ラベル）で描画。
+ *   ─ window.renderAllDay(events) で All-day タイムラインを描画。
  */
 
 /* ──────────────  Utilities (shared) ────────────── */
@@ -52,23 +52,9 @@ export function todayUtcISO() {
     return res.json(); // [{ id, title, ... }]
   }
 
-  /** チップ描画 */
-  function render(events) {
-    const wrap = document.getElementById("events");
-    if (!wrap) return;
-    wrap.innerHTML = "";
-    for (const ev of events) {
-      const chip = document.createElement("span");
-      chip.className =
-        "inline-block m-1 px-2 py-0.5 text-sm rounded bg-blue-100 text-blue-800";
-      chip.textContent = ev.title;
-      wrap.appendChild(chip);
-    }
-  }
-
   try {
     const events = await fetchEvents(todayUtcISO());
-    render(events);
+    window.renderAllDay(events);
   } catch (err) {
     console.error(err);
   }
@@ -211,12 +197,7 @@ document.addEventListener('DOMContentLoaded', () => {
     grid.appendChild(slot);
   }
 
-  const eventsEl = document.getElementById('events');
-  if (eventsEl && eventsEl.parentNode) {
-    eventsEl.insertAdjacentElement('afterend', grid);
-  } else {
-    document.body.appendChild(grid);
-  }
+  document.body.appendChild(grid);
   applyContrastClasses();
 });
 

--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -89,7 +89,6 @@
 
   <!-- ── time grid ─────────────────────────────────────────────────── -->
   <h1 class="sr-only">Day schedule</h1>
-  <div id="events"></div>
   <section id="time-grid"
            role="grid"
            aria-label="24-hour schedule grid"


### PR DESCRIPTION
## Summary
- clean up legacy `events` div from the index template
- use `window.renderAllDay()` in `app.js` to display fetched events
- simplify fallback grid injection logic

## Testing
- `pre-commit run --files schedule_app/templates/index.html schedule_app/static/js/app.js` *(fails: command not found)*
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_68674a555c5c832d925092937bad124a