### PR TITLE
Adjust calendar range to JST

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -12,3 +12,4 @@ pip-audit==2.*
 google-auth-oauthlib>=1.2.0
 pytest-cov>=5.0
 pytest-xdist>=3.5
+pytz>=2023.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask==2.3.*
 google-auth==2.*
 google-api-python-client==2.*
 google-auth-oauthlib>=1.2.0
+pytz>=2023.3

--- a/tests/unit/test_google_client_list.py
+++ b/tests/unit/test_google_client_list.py
@@ -18,8 +18,8 @@ def test_list_events_range(monkeypatch):
 
     client.list_events(date=datetime(2025, 1, 1))
 
-    assert captured["time_min"] == "2025-01-01T00:00:00Z"
-    assert captured["time_max"] == "2025-01-02T00:00:00Z"
+    assert captured["time_min"] == "2024-12-31T15:00:00Z"
+    assert captured["time_max"] == "2025-01-01T15:00:00Z"
 
 
 def test_list_events_dataclass(monkeypatch):


### PR DESCRIPTION
## Summary
- localize Google calendar event queries with pytz and convert JST dates to UTC
- declare pytz dependency for app and dev setups
- expect JST range in google client tests

## Testing
- `pre-commit run --files schedule_app/services/google_client.py tests/unit/test_google_client_list.py requirements.txt requirements.dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686750dc269c832d860c7573ffe0a1a4