### PR TITLE
Handle JST naive date for calendar API

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ parameters yield `400 Bad Request`. Invalid task, event or block data returns a
 `GET /api/calendar` returns Google events for the given day. If credentials are
 missing, expired or revoked, the endpoint responds with **401 Unauthorized** and
 provides instructions in the JSON body to re-authenticate via `/login`.
+The required `date` query parameter accepts an ISO 8601 datetime or
+`YYYY-MM-DD`. When no timezone is included, the value is interpreted as
+Asia/Tokyo and normalized to UTC before calling the Google API.
 
 The front-end will automatically build the `#time-grid` element at page load if
 it is missing.

--- a/SPEC.md
+++ b/SPEC.md
@@ -121,7 +121,7 @@ class Block:
 | DELETE | `/api/blocks/{id}`                                              | 204          | 404                         |
 | POST   | `/api/schedule/generate?date=YYYY‑MM‑DD&algo={greedy\|compact}` | 200 int[144] | 400 / 422                   |
 
-*`date` は ISO‑8601 日時 (例: `2025-01-01T09:00:00+09:00`) または `YYYY‑MM‑DD` を受け付け、値は `list_events` 呼び出し前に UTC へ正規化される。*
+*`date` は ISO‑8601 日時 (例: `2025-01-01T09:00:00+09:00`) または `YYYY‑MM‑DD` を受け付ける。タイムゾーンを含まない場合は JST (`Asia/Tokyo`) として解釈され、`list_events` 呼び出し前に UTC へ正規化される。*
 *Google Calendar API が失敗した場合は 502 Bad Gateway として応答する。*
 *認証情報が欠如・期限切れ・取り消しの場合は 401 Unauthorized を返す。*
 *サービス層の `generate_schedule()` は `date`・`algo`・`slots`・`unplaced` を含む辞書を返す。*


### PR DESCRIPTION
## Summary
- assume JST for naive `date` values in `/api/calendar`
- document calendar `date` parameter format in README and SPEC

## Testing
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_68675caf8e04832d81d39d28f0fcd38f