### PR TITLE
Reset schedule grid on new generation

### DIFF
--- a/tests/e2e/undo_disabled_after_generate.spec.ts
+++ b/tests/e2e/undo_disabled_after_generate.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+const sampleSchedule = {
+  date: '2025-01-01',
+  slots: new Array(144).fill(0),
+  unplaced: [],
+};
+
+test('undo/redo disabled after generate', async ({ page }) => {
+  await page.route('**/api/calendar**', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route('**/api/schedule/generate**', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(sampleSchedule) })
+  );
+
+  await page.goto('http://localhost:5173');
+  await page.getByTestId('generate-btn').click();
+
+  await expect(page.locator('#undo-btn')).toBeDisabled();
+  await expect(page.locator('#redo-btn')).toBeDisabled();
+});


### PR DESCRIPTION
## Summary
- expose gridState and unmarkSlot globally
- reset schedule grid, map, and history when generating
- render cleared grid first and load new schedule
- test undo/redo buttons disabled after generation

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun missing)*
- `npx playwright test --list` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68675cb141a8832daeedbfa79e5f868e