### PR TITLE
Ensure accessible single toast

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -614,12 +614,19 @@ document.addEventListener('DOMContentLoaded', () => {
  * @param {string} message
  */
 function showToast(message) {
+  // Remove any existing toast so only one is visible at a time
+  document
+    .querySelectorAll('.schedule-toast')
+    .forEach((el) => el.remove());
+
   const toast = document.createElement('div');
   toast.textContent = message;
   toast.className =
-    'fixed bottom-4 left-1/2 -translate-x-1/2 z-50 ' +
+    'schedule-toast fixed bottom-4 left-1/2 -translate-x-1/2 z-50 ' +
     'bg-red-600 text-white px-4 py-2 rounded shadow-lg ' +
     'opacity-0 transition-opacity duration-300';
+  toast.setAttribute('role', 'status');
+  toast.setAttribute('aria-live', 'polite');
 
   document.body.appendChild(toast);
 

--- a/tests/e2e/unplaced.spec.ts
+++ b/tests/e2e/unplaced.spec.ts
@@ -21,8 +21,14 @@ test('unplaced task shows red highlight & toast', async ({ page, request }) => {
   await page.getByTestId('generate-btn').click();
 
   /* ------- 3. Toast が表示される ------- */
-  const toast = page.locator('text=/未配置: TooLong[12]/');   // どちらか 1 件を許容
-  await expect(toast).toBeVisible({ timeout: 5000 });
+  const toastText = page.locator('text=/未配置: TooLong[12]/');   // どちらか 1 件を許容
+  await expect(toastText).toBeVisible({ timeout: 5000 });
+
+  // Toast should be unique and have proper ARIA attributes
+  const toast = page.locator('.schedule-toast');
+  await expect(toast).toHaveCount(1);
+  await expect(toast).toHaveAttribute('role', 'status');
+  await expect(toast).toHaveAttribute('aria-live', 'polite');
 
   /* ------- 4. サイドパネルのカードに赤クラスが付く ------- */
   const card = page.locator('[data-task-id]').filter({ hasText: 'TooLong2' });


### PR DESCRIPTION
## Summary
- ensure stale toasts are removed before showing a new toast
- add accessibility attributes to toasts
- verify toast behaviour and ARIA properties in e2e tests

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun missing)*
- `npx playwright test --list` *(fails: cannot access npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_686760f67b98832d9d50c96e4ef09638