### PR TITLE
Use baseURL in Playwright tests

### DIFF
--- a/tests/e2e/generate_button.spec.ts
+++ b/tests/e2e/generate_button.spec.ts
@@ -6,7 +6,7 @@ test('generate button triggers schedule API', async ({ page }) => {
     r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
   );
 
-  await page.goto('http://localhost:5173');
+  await page.goto('/');
 
   const [req] = await Promise.all([
     page.waitForRequest(r => r.url().includes('/api/schedule/generate')),

--- a/tests/e2e/test_keyboard_focus.spec.ts
+++ b/tests/e2e/test_keyboard_focus.spec.ts
@@ -22,7 +22,7 @@ test('keyboard focus traverses to first task card', async ({ page }) => {
   );
 
   // --- アプリ起動 ---
-  await page.goto('http://localhost:5173');
+  await page.goto('/');
   await page.waitForSelector('.task-card');       // DOM に出るまで待つ
 
   // --- Tab で task-card にフォーカスさせる ---

--- a/tests/e2e/time_grid.spec.ts
+++ b/tests/e2e/time_grid.spec.ts
@@ -4,7 +4,7 @@ test.describe('Time Grid rendering', () => {
 
   test('should display exactly 144 time slots', async ({ page }) => {
     // Webアプリを起動しているURLにアクセス
-    await page.goto('http://localhost:5173');
+    await page.goto('/');
 
     // Time Grid が存在することを確認
     const timeGrid = page.locator('#time-grid');
@@ -16,7 +16,7 @@ test.describe('Time Grid rendering', () => {
   });
 
   test('should correctly label each hour', async ({ page }) => {
-    await page.goto('http://localhost:5173');
+    await page.goto('/');
 
     // 各時刻ラベルを取得し確認
     const hourLabels = page.locator('.hour-label:not(.opacity-0)');

--- a/tests/e2e/undo_redo.spec.ts
+++ b/tests/e2e/undo_redo.spec.ts
@@ -8,7 +8,7 @@ test('Undo/Redo 動作確認', async ({ page }) => {
     r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
   );
 
-  await page.goto('http://localhost:5173');
+  await page.goto('/');
 
   /* === 1) 前回残りタスクを全削除 ========================== */
   await page.evaluate(async () => {

--- a/tests/e2e/unplaced.spec.ts
+++ b/tests/e2e/unplaced.spec.ts
@@ -1,11 +1,9 @@
 import { test, expect } from '@playwright/test';
 
-const BASE = 'http://localhost:5173';   // テスト用サーバ
-
 test('unplaced task shows red highlight & toast', async ({ page, request }) => {
   /* ------- 1. 24 h を越えるタスクを 2 件投入して容量オーバーにする ------- */
   for (const i of [1, 2]) {
-    await request.post(`${BASE}/api/tasks`, {
+    await request.post('/api/tasks', {
       data: {
         title: `TooLong${i}`,
         category: 'e2e',
@@ -17,7 +15,7 @@ test('unplaced task shows red highlight & toast', async ({ page, request }) => {
   }
 
   /* ------- 2. 画面を開き Generate ▶ をクリック ------- */
-  await page.goto(BASE);
+  await page.goto('/');
   await page.getByTestId('generate-btn').click();
 
   /* ------- 3. Toast が表示される ------- */


### PR DESCRIPTION
## Summary
- remove hard-coded localhost URLs from e2e tests
- use `page.goto('/')` or API calls with relative paths

## Testing
- `npx playwright test --list` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686760f95588832d89541674ec1c19f7