### PR TITLE
Use configurable timezone

### DIFF
--- a/schedule_app/api/calendar.py
+++ b/schedule_app/api/calendar.py
@@ -15,6 +15,7 @@ from schedule_app.services.google_client import (
     APIError,
     GoogleAPIUnauthorized,
 )
+from schedule_app.config import cfg
 
 
 bp = Blueprint("calendar_bp", __name__)
@@ -74,8 +75,8 @@ def get_calendar():
     """Return events for the given day.
 
     The required ``date`` query parameter accepts an ISO 8601 datetime or
-    ``YYYY-MM-DD``. Naive values are interpreted as Asia/Tokyo before being
-    normalized to UTC.
+    ``YYYY-MM-DD``. Naive values are interpreted in the configured timezone
+    (``cfg.TIMEZONE``) before being normalized to UTC.
     """
     date_str = request.args.get("date")
     if not date_str:
@@ -87,7 +88,7 @@ def get_calendar():
         return _problem(400, "bad-request", "invalid date")
 
     if date_obj.tzinfo is None:
-        date_obj = pytz.timezone("Asia/Tokyo").localize(date_obj)
+        date_obj = pytz.timezone(cfg.TIMEZONE).localize(date_obj)
 
     creds = session.get("credentials")
     if not creds:

--- a/schedule_app/services/google_client.py
+++ b/schedule_app/services/google_client.py
@@ -17,6 +17,7 @@ import pytz
 
 from schedule_app.models import Event
 from schedule_app.exceptions import APIError
+from schedule_app.config import cfg
 
 
 class GoogleAPIUnauthorized(APIError):
@@ -129,22 +130,23 @@ class GoogleClient:
         Parameters
         ----------
         date : datetime
-            Target day in JST. Naive values are treated as JST.
+            Target day in the configured timezone. Naive values are interpreted
+            using ``cfg.TIMEZONE``.
         """
 
         # -------------------------------
-        # UI は JST 日付を渡してくる前提。
-        # JST 00:00 を UTC に変換して 24 h 範囲を取得する。
+        # UI はローカルタイムゾーンの日付を渡してくる前提。
+        # ローカル 00:00 を UTC に変換して 24 h 範囲を取得する。
         # -------------------------------
-        JST = pytz.timezone("Asia/Tokyo")
+        local_tz = pytz.timezone(cfg.TIMEZONE)
 
         if date.tzinfo is None:
-            # naïve → JST
-            local_start = JST.localize(datetime.combine(date.date(), time.min))
+            # naïve → local timezone
+            local_start = local_tz.localize(datetime.combine(date.date(), time.min))
         else:
-            # すでに aware なら JST に合わせる
+            # すでに aware ならローカルタイムゾーンに合わせる
             local_start = (
-                date.astimezone(JST).replace(hour=0, minute=0, second=0, microsecond=0)
+                date.astimezone(local_tz).replace(hour=0, minute=0, second=0, microsecond=0)
             )
 
         start = local_start.astimezone(timezone.utc)

--- a/tests/unit/test_schedule_api_tz.py
+++ b/tests/unit/test_schedule_api_tz.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import importlib
+from datetime import date
+from flask import Flask
+
+from schedule_app.api import schedule as schedule_api
+from schedule_app.services import schedule as schedule_service
+from schedule_app import config as config_module
+
+
+def _make_app():
+    app = Flask(__name__)
+    app.register_blueprint(schedule_api.schedule_bp)
+    return app.test_client()
+
+
+def test_generate_schedule_default_timezone(monkeypatch):
+    captured = {}
+
+    def fake_generate_schedule(*, target_day: date, algo: str):
+        captured["day"] = target_day
+        return {"date": str(target_day), "slots": [], "unplaced": [], "algo": algo}
+
+    monkeypatch.setattr(schedule_service, "generate_schedule", fake_generate_schedule)
+    client = _make_app()
+    resp = client.post("/api/schedule/generate?date=2025-01-01")
+    assert resp.status_code == 200
+    assert captured["day"] == date(2024, 12, 31)
+
+
+def test_generate_schedule_custom_timezone(monkeypatch):
+    monkeypatch.setenv("TIMEZONE", "UTC")
+    importlib.reload(config_module)
+    importlib.reload(schedule_api)
+    importlib.reload(schedule_service)
+
+    captured = {}
+
+    def fake_generate_schedule(*, target_day: date, algo: str):
+        captured["day"] = target_day
+        return {"date": str(target_day), "slots": [], "unplaced": [], "algo": algo}
+
+    monkeypatch.setattr(schedule_service, "generate_schedule", fake_generate_schedule)
+    client = _make_app()
+    resp = client.post("/api/schedule/generate?date=2025-01-01")
+    assert resp.status_code == 200
+    assert captured["day"] == date(2025, 1, 1)
+
+    monkeypatch.delenv("TIMEZONE", raising=False)
+    importlib.reload(config_module)
+    importlib.reload(schedule_api)
+    importlib.reload(schedule_service)


### PR DESCRIPTION
## Summary
- allow timezone configuration in calendar API and Google client
- honor timezone when generating schedules
- add unit tests covering timezone configuration

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_6867652f87e0832db74821a5431e134e