### PR TITLE
Fix schedule API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,20 @@ All datetimes are UTC RFC 3339 strings. Validation errors return a 422 response 
 `date` is a required query parameter in `YYYY-MM-DD` format.
 <!-- TODO: support selecting different scheduling algorithms -->
 
-On success, the endpoint returns `200 OK` with just the `slots` array:
+On success, the endpoint returns `200 OK` with a JSON object:
 
 ```json
-[0, 1, 2, ...]
+{
+  "date": "2025-01-01",
+  "slots": [0, 1, 2, ...],
+  "unplaced": []
+}
 ```
 
 `slots` is an array of 144 ten-minute entries where `0` means free, `1` busy and
-`2` occupied by a task. The underlying `schedule.generate_schedule()` service
-function still returns a dictionary with `date`, `slots` and `unplaced`
-for use in other parts of the application. Missing or malformed query
-parameters yield `400 Bad Request`. Invalid task, event or block data returns a
-`422` problem response.
+`2` occupied by a task. Missing or malformed query parameters yield
+`400 Bad Request`. Invalid task, event or block data returns a `422` problem
+response.
 
 ## Calendar API
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -119,17 +119,21 @@ class Block:
 | POST   | `/api/blocks`                                                   | 201 Block    | 422                         |
 | PUT    | `/api/blocks/{id}`                                              | 200 Block    | 404 / 422                   |
 | DELETE | `/api/blocks/{id}`                                              | 204          | 404                         |
-| POST   | `/api/schedule/generate?date=YYYY‑MM‑DD&algo={greedy\|compact}` | 200 int[144] | 400 / 422                   |
+| POST   | `/api/schedule/generate?date=YYYY‑MM‑DD` | 200 Schedule | 400 / 422                   |
 
 *`date` は ISO‑8601 日時 (例: `2025-01-01T09:00:00+09:00`) または `YYYY‑MM‑DD` を受け付ける。タイムゾーンを含まない場合は JST (`Asia/Tokyo`) として解釈され、`list_events` 呼び出し前に UTC へ正規化される。*
 *Google Calendar API が失敗した場合は 502 Bad Gateway として応答する。*
 *認証情報が欠如・期限切れ・取り消しの場合は 401 Unauthorized を返す。*
 *サービス層の `generate_schedule()` は `date`・`algo`・`slots`・`unplaced` を含む辞書を返す。*
-*エンドポイントはその `slots` 配列のみを返し、長さは 144 で各要素は `0`（空き）・`1`（busy）・`2`（タスク）を表す整数。*
+*エンドポイントはその `date`・`slots`・`unplaced` を返し、`slots` の長さは 144 で各要素は `0`（空き）・`1`（busy）・`2`（タスク）を表す整数。*
 *成功例*
 
 ```json
-[0, 1, 2, ...]
+{
+  "date": "2025-01-01",
+  "slots": [0, 1, 2, ...],
+  "unplaced": []
+}
 ```
 
 *Problem Details 例*


### PR DESCRIPTION
## Summary
- align Schedule API docs with actual response structure
- clarify API response in SPEC

## Testing
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_686765302d00832dba849bc8e777f602