### PR TITLE
Set dummy env variables

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
   webServer: {
     command: 'python -m flask --app schedule_app run --port 5173',
     url: 'http://localhost:5173',
+    env: { GCP_PROJECT: 'dummy-project', GOOGLE_CLIENT_ID: 'dummy-client-id' },
     reuseExistingServer: !process.env.CI,
   },
   projects: [

--- a/tests/integration/test_schedule_api.py
+++ b/tests/integration/test_schedule_api.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import os
 import pytest
 from flask import Flask
 
 from schedule_app import create_app
+
+# ---------------------------------------------------------------------------
+# Prep dummy env vars so create_app() works without real GCP creds
+# ---------------------------------------------------------------------------
+os.environ.setdefault("GCP_PROJECT", "dummy-project")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "dummy-client-id")
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- ensure Flask app boots in tests with dummy env vars
- configure Playwright to provide the same dummy variables

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686768633344832da6f940bd36cf3e34