### PR TITLE
Handle timezone parsing for schedule API

### DIFF
--- a/tests/integration/test_schedule_api.py
+++ b/tests/integration/test_schedule_api.py
@@ -24,3 +24,11 @@ def test_generate_simple(client) -> None:
     assert set(data.keys()) == {"date", "slots", "unplaced"}
     assert data["date"] == "2025-01-01"
     assert len(data["slots"]) == 144
+
+
+def test_generate_accepts_z_datetime(client) -> None:
+    resp = client.post("/api/schedule/generate?date=2025-01-01T00:00:00Z")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, dict)
+    assert data["date"] == "2025-01-01"


### PR DESCRIPTION
## Summary
- support parsing timezone aware dates for schedule generation
- keep local date in response
- allow ISO datetimes with `Z` suffix in `date` query
- test acceptance of timezone-aware datetimes

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_6867686347e4832d93e782ad7df1ec44