### PR TITLE
Handle configurable timezone

### DIFF
--- a/schedule_app/api/calendar.py
+++ b/schedule_app/api/calendar.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 import pytz
+
+from schedule_app.config import cfg
 from http import HTTPStatus
 from dataclasses import asdict
 from zoneinfo import ZoneInfo
@@ -87,7 +89,7 @@ def get_calendar():
         return _problem(400, "bad-request", "invalid date")
 
     if date_obj.tzinfo is None:
-        date_obj = pytz.timezone("Asia/Tokyo").localize(date_obj)
+        date_obj = pytz.timezone(cfg.TIMEZONE).localize(date_obj)
 
     creds = session.get("credentials")
     if not creds:

--- a/schedule_app/services/google_client.py
+++ b/schedule_app/services/google_client.py
@@ -17,6 +17,7 @@ import pytz
 
 from schedule_app.models import Event
 from schedule_app.exceptions import APIError
+from schedule_app.config import cfg
 
 
 class GoogleAPIUnauthorized(APIError):
@@ -133,10 +134,10 @@ class GoogleClient:
         """
 
         # -------------------------------
-        # UI は JST 日付を渡してくる前提。
-        # JST 00:00 を UTC に変換して 24 h 範囲を取得する。
+        # UI は動作時のタイムゾーン(cfg.TIMEZONE)で日付を測定する前提。
+        # ローカル時間の 00:00 を UTC に変換して 24‟h 範囲を取得する。
         # -------------------------------
-        JST = pytz.timezone("Asia/Tokyo")
+        JST = pytz.timezone(cfg.TIMEZONE)
 
         if date.tzinfo is None:
             # naïve → JST


### PR DESCRIPTION
## Summary
- adapt GoogleClient and calendar API to use timezone from `cfg.TIMEZONE`
- extend unit test for GoogleClient with configurable timezone

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_68676a880034832dae1e2b7ac878fb2a