### PR TITLE
Fix schedule API test to use timezone-aware date

### DIFF
--- a/tests/integration/test_schedule_api.py
+++ b/tests/integration/test_schedule_api.py
@@ -1,10 +1,21 @@
 from __future__ import annotations
 
 import os
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 import pytest
 from flask import Flask
 
 from schedule_app import create_app
+from schedule_app.config import cfg
+
+expected = (
+    datetime.strptime("2025-01-01", "%Y-%m-%d")
+    .replace(tzinfo=ZoneInfo(cfg.TIMEZONE))
+    .astimezone(timezone.utc)
+    .date()
+    .isoformat()
+)
 
 # ---------------------------------------------------------------------------
 # Prep dummy env vars so create_app() works without real GCP creds
@@ -29,7 +40,7 @@ def test_generate_simple(client) -> None:
     data = resp.get_json()
     assert isinstance(data, dict)
     assert set(data.keys()) == {"date", "slots", "unplaced"}
-    assert data["date"] == "2025-01-01"
+    assert data["date"] == expected
     assert len(data["slots"]) == 144
 
 
@@ -38,4 +49,4 @@ def test_generate_accepts_z_datetime(client) -> None:
     assert resp.status_code == 200
     data = resp.get_json()
     assert isinstance(data, dict)
-    assert data["date"] == "2025-01-01"
+    assert data["date"] == expected


### PR DESCRIPTION
## Summary
- compute expected UTC date based on configured timezone
- update integration tests to use computed date

## Testing
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_68676a88c718832da68d8789914ea9c3