### PR TITLE
Document TIMEZONE env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ flask --app schedule_app run --debug --port 5173
 
 The `requirements.dev.txt` file includes **freezegun**, which the tests rely on.
 
+## Configuration
+
+The application reads settings from environment variables. `TIMEZONE` defines
+the default IANA zone used when parsing API dates that lack timezone
+information. It defaults to `"Asia/Tokyo"` but may be changed to any valid zone
+identifier.
+
 ## Running Tests
 
 The tests rely on the `freezegun` library to control time. Make sure it is
@@ -56,8 +63,8 @@ All datetimes are UTC RFC 3339 strings. Validation errors return a 422 response 
 
 `date` is a required query parameter that accepts an ISO‑8601 datetime
 (e.g. `2025-01-01T09:00:00+09:00`) or `YYYY-MM-DD`. When the value lacks a
-timezone, it is interpreted using `cfg.TIMEZONE` before being normalized to
-UTC.
+timezone, it is interpreted using `cfg.TIMEZONE` (default `"Asia/Tokyo"`) before
+being normalized to UTC.
 <!-- TODO: support selecting different scheduling algorithms -->
 On success, the endpoint returns `200 OK` with a JSON object:
 
@@ -82,8 +89,9 @@ response.
 missing, expired or revoked, the endpoint responds with **401 Unauthorized** and
 provides instructions in the JSON body to re-authenticate via `/login`.
 The required `date` query parameter accepts an ISO 8601 datetime or
-`YYYY-MM-DD`. When no timezone is included, the value is interpreted as
-Asia/Tokyo and normalized to UTC before calling the Google API.
+`YYYY-MM-DD`. When no timezone is included, the value is interpreted using
+`cfg.TIMEZONE` (default `"Asia/Tokyo"`) and normalized to UTC before calling the
+Google API.
 
 The front-end will automatically build the `#time-grid` element at page load if
 it is missing.

--- a/SPEC.md
+++ b/SPEC.md
@@ -121,7 +121,7 @@ class Block:
 | DELETE | `/api/blocks/{id}`                                              | 204          | 404                         |
 | POST   | `/api/schedule/generate?date=YYYY‑MM‑DD` | 200 Schedule | 400 / 422                   |
 
-*`date` は ISO‑8601 日時 (例: `2025-01-01T09:00:00+09:00`) または `YYYY‑MM‑DD` を受け付ける。タイムゾーンを含まない場合は JST (`Asia/Tokyo`) として解釈され、`list_events` 呼び出し前に UTC へ正規化される。*
+*`date` は ISO‑8601 日時 (例: `2025-01-01T09:00:00+09:00`) または `YYYY‑MM‑DD` を受け付ける。タイムゾーンを含まない場合は `TIMEZONE` 環境変数で指定されたゾーン（既定 `"Asia/Tokyo"`）として解釈し、`list_events` 呼び出し前に UTC へ正規化される。*
 *Google Calendar API が失敗した場合は 502 Bad Gateway として応答する。*
 *認証情報が欠如・期限切れ・取り消しの場合は 401 Unauthorized を返す。*
 *サービス層の `generate_schedule()` は `date`・`algo`・`slots`・`unplaced` を含む辞書を返す。*
@@ -186,6 +186,7 @@ def quantize(dt: datetime, *, up: bool) -> datetime:
 | ----- | ------------------------------------------------------------ |
 | 内部    | UTC (RFC 3339) 固定                                            |
 | 表示    | JST (Asia/Tokyo) — `luxon` (front) / `pytz` (back)           |
+| TIMEZONE 環境変数 | タイムゾーン省略時に解釈する既定値。デフォルトは `"Asia/Tokyo"` |
 | TZ 検証 | Google イベントの `event.timeZone` が IANA TZDB 2025‑b 以外 → UTC 扱い |
 | DST   | `pytz` 変換で ±1 h ずれ防止                                         |
 


### PR DESCRIPTION
## Summary
- clarify how TIMEZONE affects date parsing
- document TIMEZONE in README and SPEC

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_68676a8a119c832d890785ec7dd7c797