### PR TITLE
Update schedule API test env setup

### DIFF
--- a/tests/integration/test_schedule_api.py
+++ b/tests/integration/test_schedule_api.py
@@ -4,13 +4,16 @@ import os
 import pytest
 from flask import Flask
 
-from schedule_app import create_app
-
 # ---------------------------------------------------------------------------
 # Prep dummy env vars so create_app() works without real GCP creds
 # ---------------------------------------------------------------------------
 os.environ.setdefault("GCP_PROJECT", "dummy-project")
 os.environ.setdefault("GOOGLE_CLIENT_ID", "dummy-client-id")
+
+from schedule_app.config import cfg
+from schedule_app import create_app
+
+expected = cfg.TIMEZONE
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- load `schedule_app.config.cfg` after prepping env vars
- compute `expected` after importing `cfg`

## Testing
- `ruff check tests/integration/test_schedule_api.py`
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_68676e681444832d8e2b9de75bdcc612