### PR TITLE
Fix timezone handling in schedule API

### DIFF
--- a/schedule_app/api/schedule.py
+++ b/schedule_app/api/schedule.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+from schedule_app.config import cfg
 from flask import Blueprint, abort, jsonify, request
 
 from schedule_app.services import schedule
@@ -27,7 +30,7 @@ def generate_schedule():  # noqa: D401 - simple endpoint
 
     local_day = dt.date()
     if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
+        dt = dt.replace(tzinfo=ZoneInfo(cfg.TIMEZONE))
     date_utc = dt.astimezone(timezone.utc)
 
     algo = request.args.get("algo", "greedy")

--- a/tests/integration/test_schedule_api.py
+++ b/tests/integration/test_schedule_api.py
@@ -39,3 +39,23 @@ def test_generate_accepts_z_datetime(client) -> None:
     data = resp.get_json()
     assert isinstance(data, dict)
     assert data["date"] == "2025-01-01"
+
+
+def test_naive_date_uses_cfg_timezone(client) -> None:
+    from datetime import datetime, timezone
+    from zoneinfo import ZoneInfo
+    from unittest.mock import patch
+
+    tz = ZoneInfo("Asia/Tokyo")
+    expected = datetime(2025, 1, 1, tzinfo=tz).astimezone(timezone.utc).date()
+
+    with patch("schedule_app.services.schedule.generate_schedule") as mock_gen:
+        mock_gen.return_value = {"date": "x", "algo": "greedy", "slots": [0] * 144, "unplaced": []}
+        resp = client.post("/api/schedule/generate?date=2025-01-01")
+        assert resp.status_code == 200
+        mock_gen.assert_called_once()
+        args, kwargs = mock_gen.call_args
+        assert kwargs["target_day"] == expected
+        assert kwargs["algo"] == "greedy"
+    data = resp.get_json()
+    assert data["date"] == "2025-01-01"


### PR DESCRIPTION
## Summary
- parse naive dates using cfg.TIMEZONE in schedule API
- verify naive date handling in schedule API tests

## Testing
- `ruff check .`
- `pytest -q` *(fails: Skipped: freezegun is required to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_68676e68b99c832da32f755578f25406