### PR TITLE
Set dummy GCP env vars for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,11 +7,18 @@ package isn't installed.
 import sys
 import pathlib
 import importlib
+import os
 import pytest
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+# ---------------------------------------------------------------------------
+# Default environment so schedule_app.config imports without real creds
+# ---------------------------------------------------------------------------
+os.environ.setdefault("GCP_PROJECT", "dummy-project")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "dummy-client-id")
 
 if importlib.util.find_spec("freezegun") is None:
     pytest.skip("freezegun is required to run tests", allow_module_level=True)


### PR DESCRIPTION
## Summary
- ensure `schedule_app.config` can load when credentials are missing
- define fallback env vars in `tests/conftest.py`

## Testing
- `pre-commit run --files tests/conftest.py` *(fails: pre-commit not installed)*
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_68676e78d6c8832db53a22858b7309e2