### PR TITLE
Fix timezone test import order

### DIFF
--- a/schedule_app/services/google_client.py
+++ b/schedule_app/services/google_client.py
@@ -15,6 +15,8 @@ import json
 from datetime import datetime, time, timedelta, timezone
 import pytz
 
+from schedule_app.config import cfg
+
 from schedule_app.models import Event
 from schedule_app.exceptions import APIError
 
@@ -133,18 +135,18 @@ class GoogleClient:
         """
 
         # -------------------------------
-        # UI は JST 日付を渡してくる前提。
-        # JST 00:00 を UTC に変換して 24 h 範囲を取得する。
+        # UI は指定されたタイムゾーンの日付を渡してくる前提。
+        # TIMEZONE 環境変数で指定されたゾーンで 00:00 を計算し、UTC へ変換する。
         # -------------------------------
-        JST = pytz.timezone("Asia/Tokyo")
+        local_tz = pytz.timezone(cfg.TIMEZONE)
 
         if date.tzinfo is None:
-            # naïve → JST
-            local_start = JST.localize(datetime.combine(date.date(), time.min))
+            # naïve → local timezone
+            local_start = local_tz.localize(datetime.combine(date.date(), time.min))
         else:
-            # すでに aware なら JST に合わせる
+            # すでに aware なら設定タイムゾーンに合わせる
             local_start = (
-                date.astimezone(JST).replace(hour=0, minute=0, second=0, microsecond=0)
+                date.astimezone(local_tz).replace(hour=0, minute=0, second=0, microsecond=0)
             )
 
         start = local_start.astimezone(timezone.utc)

--- a/tests/unit/test_google_client_list.py
+++ b/tests/unit/test_google_client_list.py
@@ -47,3 +47,34 @@ def test_list_events_dataclass(monkeypatch):
     assert ev.end_utc == datetime(2025, 1, 1, 2, 0, tzinfo=timezone.utc)
 
 
+def test_list_events_timezone_env(monkeypatch):
+    """GoogleClient should respect TIMEZONE environment variable."""
+
+    import importlib
+
+    monkeypatch.setenv("TIMEZONE", "UTC")
+
+    config_module = importlib.import_module("schedule_app.config")
+    importlib.reload(config_module)
+    google_client_module = importlib.import_module(
+        "schedule_app.services.google_client"
+    )
+    importlib.reload(google_client_module)
+
+    client = google_client_module.GoogleClient(credentials=None)
+
+    captured: dict[str, str] = {}
+
+    def fake_fetch(*, time_min: str, time_max: str) -> list[dict]:
+        captured["time_min"] = time_min
+        captured["time_max"] = time_max
+        return []
+
+    monkeypatch.setattr(client, "fetch_calendar_events", fake_fetch)
+
+    client.list_events(date=datetime(2025, 1, 1))
+
+    assert captured["time_min"] == "2025-01-01T00:00:00Z"
+    assert captured["time_max"] == "2025-01-02T00:00:00Z"
+
+


### PR DESCRIPTION
## Summary
- ensure TIMEZONE changes apply by reloading config before importing GoogleClient

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_68676e7a7b64832dbc682b2d5b2e03e1