### PR TITLE
Update timezone docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The `requirements.dev.txt` file includes **freezegun**, which the tests rely on.
 
 The application reads settings from environment variables. `TIMEZONE` defines
 the default IANA zone used when parsing API dates that lack timezone
-information. It defaults to `"Asia/Tokyo"` but may be changed to any valid zone
+information. It defaults to `cfg.TIMEZONE` but may be changed to any valid zone
 identifier.
 
 ## Running Tests
@@ -63,7 +63,7 @@ All datetimes are UTC RFC 3339 strings. Validation errors return a 422 response 
 
 `date` is a required query parameter that accepts an ISO‑8601 datetime
 (e.g. `2025-01-01T09:00:00+09:00`) or `YYYY-MM-DD`. When the value lacks a
-timezone, it is interpreted using `cfg.TIMEZONE` (default `"Asia/Tokyo"`) before
+timezone, it is interpreted using `cfg.TIMEZONE` before
 being normalized to UTC.
 <!-- TODO: support selecting different scheduling algorithms -->
 On success, the endpoint returns `200 OK` with a JSON object:
@@ -90,7 +90,7 @@ missing, expired or revoked, the endpoint responds with **401 Unauthorized** and
 provides instructions in the JSON body to re-authenticate via `/login`.
 The required `date` query parameter accepts an ISO 8601 datetime or
 `YYYY-MM-DD`. When no timezone is included, the value is interpreted using
-`cfg.TIMEZONE` (default `"Asia/Tokyo"`) and normalized to UTC before calling the
+`cfg.TIMEZONE` and normalized to UTC before calling the
 Google API.
 
 The front-end will automatically build the `#time-grid` element at page load if

--- a/SPEC.md
+++ b/SPEC.md
@@ -121,7 +121,7 @@ class Block:
 | DELETE | `/api/blocks/{id}`                                              | 204          | 404                         |
 | POST   | `/api/schedule/generate?date=YYYY‑MM‑DD` | 200 Schedule | 400 / 422                   |
 
-*`date` は ISO‑8601 日時 (例: `2025-01-01T09:00:00+09:00`) または `YYYY‑MM‑DD` を受け付ける。タイムゾーンを含まない場合は `TIMEZONE` 環境変数で指定されたゾーン（既定 `"Asia/Tokyo"`）として解釈し、`list_events` 呼び出し前に UTC へ正規化される。*
+*`date` は ISO‑8601 日時 (例: `2025-01-01T09:00:00+09:00`) または `YYYY‑MM‑DD` を受け付ける。タイムゾーンを含まない場合は `TIMEZONE` 環境変数で指定されたゾーン（既定 `cfg.TIMEZONE`）として解釈し、`list_events` 呼び出し前に UTC へ正規化される。*
 *Google Calendar API が失敗した場合は 502 Bad Gateway として応答する。*
 *認証情報が欠如・期限切れ・取り消しの場合は 401 Unauthorized を返す。*
 *サービス層の `generate_schedule()` は `date`・`algo`・`slots`・`unplaced` を含む辞書を返す。*
@@ -185,8 +185,8 @@ def quantize(dt: datetime, *, up: bool) -> datetime:
 | 項目    | 内容                                                           |
 | ----- | ------------------------------------------------------------ |
 | 内部    | UTC (RFC 3339) 固定                                            |
-| 表示    | JST (Asia/Tokyo) — `luxon` (front) / `pytz` (back)           |
-| TIMEZONE 環境変数 | タイムゾーン省略時に解釈する既定値。デフォルトは `"Asia/Tokyo"` |
+| 表示    | JST (`cfg.TIMEZONE`) — `luxon` (front) / `pytz` (back)           |
+| TIMEZONE 環境変数 | タイムゾーン省略時に解釈する既定値。デフォルトは `cfg.TIMEZONE` |
 | TZ 検証 | Google イベントの `event.timeZone` が IANA TZDB 2025‑b 以外 → UTC 扱い |
 | DST   | `pytz` 変換で ±1 h ずれ防止                                         |
 

--- a/schedule_app/api/calendar.py
+++ b/schedule_app/api/calendar.py
@@ -74,8 +74,8 @@ def get_calendar():
     """Return events for the given day.
 
     The required ``date`` query parameter accepts an ISO 8601 datetime or
-    ``YYYY-MM-DD``. Naive values are interpreted as Asia/Tokyo before being
-    normalized to UTC.
+    ``YYYY-MM-DD``. Naive values are interpreted using ``cfg.TIMEZONE`` before
+    being normalized to UTC.
     """
     date_str = request.args.get("date")
     if not date_str:


### PR DESCRIPTION
## Summary
- document cfg.TIMEZONE in calendar API docstring
- replace hard-coded Asia/Tokyo with cfg.TIMEZONE in README
- mention cfg.TIMEZONE in SPEC

## Testing
- `pre-commit run --files schedule_app/api/calendar.py README.md SPEC.md` *(fails: command not found)*
- `pytest -q` *(fails: missing freezegun)*

------
https://chatgpt.com/codex/tasks/task_e_68676e7a9c68832d8b1b57bdae0e31f6