### PR TITLE
Fix order of env vars in tests

### DIFF
--- a/tests/integration/test_schedule_api.py
+++ b/tests/integration/test_schedule_api.py
@@ -4,13 +4,13 @@ import os
 import pytest
 from flask import Flask
 
-from schedule_app import create_app
-
 # ---------------------------------------------------------------------------
 # Prep dummy env vars so create_app() works without real GCP creds
 # ---------------------------------------------------------------------------
 os.environ.setdefault("GCP_PROJECT", "dummy-project")
 os.environ.setdefault("GOOGLE_CLIENT_ID", "dummy-client-id")
+
+from schedule_app import create_app
 
 
 @pytest.fixture()

--- a/tests/integration/test_schedule_api.py
+++ b/tests/integration/test_schedule_api.py
@@ -10,11 +10,10 @@ from flask import Flask
 os.environ.setdefault("GCP_PROJECT", "dummy-project")
 os.environ.setdefault("GOOGLE_CLIENT_ID", "dummy-client-id")
 
-from schedule_app import create_app
-
-
 @pytest.fixture()
 def app() -> Flask:
+    from schedule_app import create_app
+
     return create_app(testing=True)
 
 


### PR DESCRIPTION
## Summary
- move `os.environ.setdefault` calls above `create_app` import

## Testing
- `python -m pytest -q` *(fails: freezegun is required)*
- `pip install -r requirements.dev.txt` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686772865498832d92bd3a0171e4eedd