### PR TITLE
Fix lint warning

### DIFF
--- a/tests/integration/test_schedule_api.py
+++ b/tests/integration/test_schedule_api.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
## Summary
- silence E402 import errors in schedule API integration tests

## Testing
- `ruff check tests/integration/test_schedule_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68677399f2e8832dadb8f4a911849720