### PR TITLE
Handle timezone for naive datetimes

### DIFF
--- a/schedule_app/api/schedule.py
+++ b/schedule_app/api/schedule.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import pytz
 from flask import Blueprint, abort, jsonify, request
+
+from schedule_app.config import cfg
 
 from schedule_app.services import schedule
 
@@ -27,7 +30,8 @@ def generate_schedule():  # noqa: D401 - simple endpoint
 
     local_day = dt.date()
     if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
+        tz = pytz.timezone(cfg.TIMEZONE)
+        dt = tz.localize(dt)
     date_utc = dt.astimezone(timezone.utc)
 
     algo = request.args.get("algo", "greedy")

--- a/tests/integration/test_schedule_api.py
+++ b/tests/integration/test_schedule_api.py
@@ -39,3 +39,21 @@ def test_generate_accepts_z_datetime(client) -> None:
     data = resp.get_json()
     assert isinstance(data, dict)
     assert data["date"] == "2025-01-01"
+
+
+def test_generate_localizes_naive_datetime(client) -> None:
+    """Naive datetimes are interpreted using cfg.TIMEZONE."""
+    from datetime import datetime, timezone
+    from unittest.mock import patch
+    import pytz
+    from schedule_app.config import cfg
+
+    fake_result = {"date": "2025-01-01", "algo": "greedy", "slots": [0] * 144, "unplaced": []}
+    with patch("schedule_app.api.schedule.schedule.generate_schedule", return_value=fake_result) as mock_gen:
+        resp = client.post("/api/schedule/generate?date=2025-01-01T00:00:00")
+        assert resp.status_code == 200
+        mock_gen.assert_called_once()
+        target_day = mock_gen.call_args.kwargs["target_day"]
+        tz = pytz.timezone(cfg.TIMEZONE)
+        dt = tz.localize(datetime(2025, 1, 1, 0, 0))
+        assert target_day == dt.astimezone(timezone.utc).date()


### PR DESCRIPTION
## Summary
- ensure `/api/schedule/generate` localizes naive datetimes
- test that naive datetimes use `cfg.TIMEZONE`

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686773992450832d8fa2550c8a638562