### PR TITLE
Remove unused OAUTH_REDIRECT_URI

### DIFF
--- a/schedule_app/config.py
+++ b/schedule_app/config.py
@@ -36,10 +36,6 @@ class _Config:
     # --- OAuth ---
     GOOGLE_CLIENT_ID: str = os.environ["GOOGLE_CLIENT_ID"]
     GOOGLE_CLIENT_SECRET: str | None = os.getenv("GOOGLE_CLIENT_SECRET")  # PKCEでは不要
-    OAUTH_REDIRECT_URI: str = os.getenv(
-        "OAUTH_REDIRECT_URI",
-        "http://localhost:5173/oauth2callback",
-    )
 
     # --- App Settings ---
     TIMEZONE: str = os.getenv("TIMEZONE", "Asia/Tokyo")


### PR DESCRIPTION
## Summary
- delete the unused `OAUTH_REDIRECT_URI` entry from configuration

## Testing
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_686773ab60c0832db8d9c9bfd2bc9a5b