### PR TITLE
Move imports inside unauthorized fetch test

### DIFF
--- a/tests/unit/test_google_client_fetch.py
+++ b/tests/unit/test_google_client_fetch.py
@@ -1,11 +1,11 @@
 import pytest
 from urllib.error import HTTPError
 
-from schedule_app.services.google_client import GoogleClient, GoogleAPIUnauthorized
-
 
 @pytest.mark.parametrize("status", [401, 403])
 def test_fetch_unauthorized(monkeypatch, status):
+    from schedule_app.services.google_client import GoogleClient, GoogleAPIUnauthorized
+
     client = GoogleClient(credentials={"access_token": "tok"})
 
     def raise_error(req):  # pragma: no cover - stub


### PR DESCRIPTION
## Summary
- ensure `test_fetch_unauthorized` imports GoogleClient lazily

## Testing
- `pytest -q tests/unit/test_google_client_fetch.py` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_686773b1c5b8832db3e7b109a2a8708b