### PR TITLE
Add timezone env reload test

### DIFF
--- a/tests/unit/test_create_app_gclient.py
+++ b/tests/unit/test_create_app_gclient.py
@@ -1,8 +1,8 @@
 from schedule_app import create_app
-from schedule_app.services.google_client import GoogleClient
 
 
 def test_create_app_has_google_client_extension():
+    from schedule_app.services.google_client import GoogleClient
     app = create_app(testing=True)
     assert "gclient" in app.extensions
     assert isinstance(app.extensions["gclient"], GoogleClient)

--- a/tests/unit/test_google_client_fetch.py
+++ b/tests/unit/test_google_client_fetch.py
@@ -1,11 +1,12 @@
 import pytest
 from urllib.error import HTTPError
 
-from schedule_app.services.google_client import GoogleClient, GoogleAPIUnauthorized
 
 
 @pytest.mark.parametrize("status", [401, 403])
 def test_fetch_unauthorized(monkeypatch, status):
+    from schedule_app.services.google_client import GoogleClient, GoogleAPIUnauthorized
+
     client = GoogleClient(credentials={"access_token": "tok"})
 
     def raise_error(req):  # pragma: no cover - stub


### PR DESCRIPTION
## Summary
- test GoogleClient uses TIMEZONE env var when reloaded
- import GoogleClient inside tests so module reloads take effect

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686773a902a4832d837b4cb038f2e67d