### PR TITLE
Handle JST date parsing

### DIFF
--- a/tests/integration/test_schedule_api.py
+++ b/tests/integration/test_schedule_api.py
@@ -39,3 +39,11 @@ def test_generate_accepts_z_datetime(client) -> None:
     data = resp.get_json()
     assert isinstance(data, dict)
     assert data["date"] == "2025-01-01"
+
+
+def test_generate_accepts_naive_datetime(client) -> None:
+    resp = client.post("/api/schedule/generate?date=2025-01-01T00:00:00")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, dict)
+    assert data["date"] == "2025-01-01"


### PR DESCRIPTION
## Summary
- interpret `date` parameter in `/api/schedule/generate` using new rules
- allow ISO datetime strings and plain dates in Asia/Tokyo timezone
- support naive datetimes in API tests

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_6867c68312a4832d813737ac9061c859