### PR TITLE
Clarify freezegun requirement in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ identifier.
 
 ## Running Tests
 
-The tests rely on the `freezegun` library to control time. Make sure it is
-installed from `requirements.dev.txt` before invoking `pytest`:
+The test suite depends on the `freezegun` library to control time. Tests will
+not run until it has been installed from `requirements.dev.txt`:
 
 ```bash
-pip install -r requirements.dev.txt  # includes freezegun
+pip install -r requirements.dev.txt
 pytest -q
 ```
 


### PR DESCRIPTION
## Summary
- clarify that tests require the `freezegun` package

## Testing
- `pip install -r requirements.dev.txt` *(fails: no internet)*
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_6867c684a338832d88c84d75ac0bcba6