### PR TITLE
Add midday timezone test & fix naive datetime handling

### DIFF
--- a/schedule_app/api/calendar.py
+++ b/schedule_app/api/calendar.py
@@ -7,6 +7,7 @@ from dataclasses import asdict
 from zoneinfo import ZoneInfo
 
 from schedule_app.models import Event
+from schedule_app.config import cfg
 
 from flask import Blueprint, request, session, jsonify
 
@@ -87,7 +88,7 @@ def get_calendar():
         return _problem(400, "bad-request", "invalid date")
 
     if date_obj.tzinfo is None:
-        date_obj = pytz.timezone("Asia/Tokyo").localize(date_obj)
+        date_obj = pytz.timezone(cfg.TIMEZONE).localize(date_obj)
 
     creds = session.get("credentials")
     if not creds:

--- a/schedule_app/api/schedule.py
+++ b/schedule_app/api/schedule.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, time, timezone
 from zoneinfo import ZoneInfo
 from flask import Blueprint, abort, jsonify, request
 


### PR DESCRIPTION
## Summary
- use cfg.TIMEZONE when interpreting datetimes without timezone in schedule API
- extend integration tests with midday naive datetime case

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6867cabb7c60832d9213366191ac0443