### PR TITLE
Add midday timezone test & fix naive datetime handling

### DIFF
--- a/schedule_app/api/schedule.py
+++ b/schedule_app/api/schedule.py
@@ -5,6 +5,7 @@ from zoneinfo import ZoneInfo
 from flask import Blueprint, abort, jsonify, request
 
 from schedule_app.services import schedule
+from schedule_app.config import cfg
 
 
 bp = Blueprint("schedule", __name__, url_prefix="/api/schedule")
@@ -18,21 +19,22 @@ def generate_schedule():  # noqa: D401 - simple endpoint
     if not date_str:
         abort(400, description="date parameter required")
 
+    tz = ZoneInfo(cfg.TIMEZONE)
+
     if "T" in date_str:
         try:
             dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
         except ValueError:
             abort(400, description="invalid date format")
         if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        local_day = dt.astimezone(ZoneInfo("Asia/Tokyo")).date()
+            dt = dt.replace(tzinfo=tz)
+        local_day = dt.astimezone(tz).date()
         target_day_utc = dt.astimezone(timezone.utc)
     else:
         try:
             local_day = datetime.strptime(date_str, "%Y-%m-%d").date()
         except ValueError:
             abort(400, description="invalid date format")
-        tz = ZoneInfo("Asia/Tokyo")
         target_day_utc = (
             datetime.combine(local_day, datetime.min.time(), tzinfo=tz)
             .astimezone(timezone.utc)

--- a/tests/integration/test_schedule_api.py
+++ b/tests/integration/test_schedule_api.py
@@ -47,3 +47,11 @@ def test_generate_accepts_naive_datetime(client) -> None:
     data = resp.get_json()
     assert isinstance(data, dict)
     assert data["date"] == "2025-01-01"
+
+
+def test_generate_naive_datetime_midday(client) -> None:
+    resp = client.post("/api/schedule/generate?date=2025-07-05T15:00:00")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, dict)
+    assert data["date"] == "2025-07-05"


### PR DESCRIPTION
## Summary
- use cfg.TIMEZONE when interpreting datetimes without timezone in schedule API
- extend integration tests with midday naive datetime case

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6867cabb7c60832d9213366191ac0443