### PR TITLE
Clarify schedule generation timezone handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ All datetimes are UTC RFC 3339 strings. Validation errors return a 422 response 
 
 `date` is a required query parameter that accepts an ISO‑8601 datetime
 (e.g. `2025-01-01T09:00:00+09:00`) or `YYYY-MM-DD`. When the value lacks a
-timezone, it is interpreted using `cfg.TIMEZONE` before
-being normalized to UTC.
+timezone, it is interpreted using `cfg.TIMEZONE` (JST). The endpoint forwards
+this JST date to the service layer, which converts it to UTC.
 <!-- TODO: support selecting different scheduling algorithms -->
 On success, the endpoint returns `200 OK` with a JSON object:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -121,7 +121,7 @@ class Block:
 | DELETE | `/api/blocks/{id}`                                              | 204          | 404                         |
 | POST   | `/api/schedule/generate?date=YYYY‑MM‑DD` | 200 Schedule | 400 / 422                   |
 
-*`date` は ISO‑8601 日時 (例: `2025-01-01T09:00:00+09:00`) または `YYYY‑MM‑DD` を受け付ける。タイムゾーンを含まない場合は `TIMEZONE` 環境変数で指定されたゾーン（既定 `cfg.TIMEZONE`）として解釈し、`list_events` 呼び出し前に UTC へ正規化される。*
+*`date` は ISO‑8601 日時 (例: `2025-01-01T09:00:00+09:00`) または `YYYY‑MM‑DD` を受け付ける。タイムゾーンを含まない場合は `TIMEZONE` 環境変数で指定されたゾーン（既定 `cfg.TIMEZONE`）として解釈し、エンドポイントはこの JST 日付をサービス層へそのまま渡し、サービス側で UTC へ変換する。*
 *Google Calendar API が失敗した場合は 502 Bad Gateway として応答する。*
 *認証情報が欠如・期限切れ・取り消しの場合は 401 Unauthorized を返す。*
 *サービス層の `generate_schedule()` は `date`・`algo`・`slots`・`unplaced` を含む辞書を返す。*


### PR DESCRIPTION
## Summary
- document schedule API timezone behaviour in README
- clarify JST forwarding before UTC conversion in SPEC

## Testing
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_6867d84624b4832da5794b2445df997f