### PR TITLE
Refactor schedule API date parsing

### DIFF
--- a/schedule_app/api/schedule.py
+++ b/schedule_app/api/schedule.py
@@ -34,12 +34,16 @@ def generate_schedule():  # noqa: D401 - simple endpoint
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=tz)
 
-        local_day = dt.astimezone(tz).date()
+        local_dt = dt.astimezone(tz)
     else:
         try:
-            local_day = datetime.strptime(date_str, "%Y-%m-%d").date()
+            local_dt = datetime.strptime(date_str, "%Y-%m-%d")
         except ValueError:
             abort(400, description="invalid date format")
+
+        local_dt = local_dt.replace(tzinfo=tz)
+
+    local_day = local_dt.date()
 
     algo = request.args.get("algo", "greedy")
     if algo not in {"greedy", "compact"}:


### PR DESCRIPTION
## Summary
- parse the query date into a timezone-aware datetime
- call generate_schedule with the local date

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_6867dbedcb2c832dab2ada00bddcaa29