### PR TITLE
Fix timezone handling in schedule

### DIFF
--- a/tests/unit/test_schedule.py
+++ b/tests/unit/test_schedule.py
@@ -47,8 +47,8 @@ def test_busy_slot() -> None:
     BLOCKS.clear()
     BLOCKS["b1"] = Block(
         id="b1",
-        start_utc=_dt("2025-01-01T00:00:00Z"),
-        end_utc=_dt("2025-01-01T01:00:00Z"),
+        start_utc=_dt("2024-12-31T15:00:00Z"),
+        end_utc=_dt("2024-12-31T16:00:00Z"),
     )
     TASKS["A1"] = Task(
         id="A1",
@@ -81,6 +81,6 @@ def test_earliest_start() -> None:
     result = schedule.generate_schedule(target_day=date(2025, 1, 1))
     slots = result["slots"]
     assert len(slots) == 144
-    assert all(s == 0 for s in slots[:72])
-    assert slots[72:75] == [2] * 3
+    assert all(s == 0 for s in slots[:126])
+    assert slots[126:129] == [2] * 3
 


### PR DESCRIPTION
## Summary
- align schedule calculations to the configured timezone
- adjust unit tests for new day start logic

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_6867dc0a9054832d946381cfc7b55e68