### PR TITLE
Add timezone helper

### DIFF
--- a/schedule_app/api/schedule.py
+++ b/schedule_app/api/schedule.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 from datetime import datetime
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
-import pytz
 from flask import Blueprint, abort, jsonify, request
 
 from schedule_app.services import schedule
-from schedule_app.config import cfg
 
 bp = Blueprint("schedule", __name__, url_prefix="/api/schedule")
 schedule_bp = bp
@@ -19,11 +16,7 @@ def generate_schedule():  # noqa: D401 - simple endpoint
     if not date_str:
         abort(400, description="date parameter required")
 
-    TZ_NAME = getattr(cfg, "TIMEZONE", "Asia/Tokyo")
-    try:
-        tz = ZoneInfo(TZ_NAME)
-    except ZoneInfoNotFoundError:
-        tz = pytz.timezone(TZ_NAME)
+    tz = schedule._jst()
 
     if "T" in date_str:
         try:

--- a/schedule_app/services/schedule.py
+++ b/schedule_app/services/schedule.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from datetime import date, datetime, timezone
 from typing import Literal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+import pytz
+
+from schedule_app.config import cfg
 
 from schedule_app.models import Block, Event, Task
 from schedule_app.services.rounding import quantize
@@ -12,6 +16,18 @@ __all__ = ["generate", "generate_schedule"]
 
 SLOT_MIN = 10
 DAY_SLOTS = 144
+
+
+def _jst():
+    """Return the configured timezone.
+
+    Tries :class:`ZoneInfo` first and falls back to :mod:`pytz` if the zone
+    is not available.
+    """
+    try:
+        return ZoneInfo(cfg.TIMEZONE)
+    except ZoneInfoNotFoundError:
+        return pytz.timezone(cfg.TIMEZONE)
 
 
 def _day_start(date_utc: datetime) -> datetime:


### PR DESCRIPTION
## Summary
- add `_jst` in services to resolve configured timezone
- use helper in schedule API instead of constructing `ZoneInfo`

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_6867dc0bdc64832db2379b7749a23b1e