### PR TITLE
Update timezone description for generate_schedule

### DIFF
--- a/schedule_app/services/schedule.py
+++ b/schedule_app/services/schedule.py
@@ -133,7 +133,8 @@ def generate_schedule(target_day: date, *, algo: str = "greedy") -> dict:
     Parameters
     ----------
     target_day:
-        Target day in UTC.
+        Date in the configured timezone (JST by default). It will be
+        converted to UTC internally.
     algo:
         Scheduling algorithm to use. Only ``"greedy"`` or ``"compact"`` are
         currently supported.


### PR DESCRIPTION
## Summary
- clarify that `generate_schedule` accepts a date in the configured timezone and converts it to UTC internally

## Testing
- `ruff check schedule_app/services/schedule.py`
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_6867ded9a5f4832db75a367751f7fbed