### PR TITLE
Remove _day_start helper

### DIFF
--- a/schedule_app/services/schedule.py
+++ b/schedule_app/services/schedule.py
@@ -30,14 +30,6 @@ def _jst():
         return pytz.timezone(cfg.TIMEZONE)
 
 
-def _day_start(date_utc: datetime) -> datetime:
-    """Return ``date_utc`` normalized to the beginning of that UTC day."""
-    if date_utc.tzinfo is None:
-        date_utc = date_utc.replace(tzinfo=timezone.utc)
-    else:
-        date_utc = date_utc.astimezone(timezone.utc)
-    return datetime.combine(date_utc.date(), datetime.min.time(), tzinfo=timezone.utc)
-
 
 def _to_index(dt: datetime, *, base: datetime) -> int:
     delta = dt - base


### PR DESCRIPTION
## Summary
- delete the unused `_day_start` function from the schedule service

## Testing
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_6867dedb0cc4832db94568842982aa5a