### PR TITLE
Add print UI hidden e2e test

### DIFF
--- a/tests/e2e/print_ui_hidden.spec.ts
+++ b/tests/e2e/print_ui_hidden.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+test('UI elements hidden in print media', async ({ page }) => {
+  const response = await page.goto('/');
+  expect(response?.status()).toBe(200);
+
+  await page.emulateMedia({ media: 'print' });
+
+  await expect(page.locator('header')).toBeHidden();
+
+  for (const selector of ['#app-header', '#side-pane']) {
+    const loc = page.locator(selector);
+    if (await loc.count() > 0) {
+      await expect(loc).toBeHidden();
+    } else {
+      await expect(loc).toHaveCount(0);
+    }
+  }
+
+  for (const selector of ['.toolbar', 'button', '.no-print']) {
+    const loc = page.locator(selector);
+    if (await loc.count() > 0) {
+      await expect(loc).toBeHidden();
+    } else {
+      await expect(loc).toHaveCount(0);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- check that header and toolbar elements are hidden when using print media
- assert `/` route responds with HTTP 200

## Testing
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_686c68be0af0832dbb5f15c0f98ee152