### PR TITLE
Ensure print CSS loads after Tailwind

### DIFF
--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -4,7 +4,6 @@
 <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
 <link rel="stylesheet" href="/static/css/styles.css">
 <link rel="stylesheet" href="/static/css/a11y.css">
-<link rel="stylesheet" href="/static/css/print.css" media="print">
 </head>
 <body>
 <header
@@ -129,6 +128,13 @@
         ul.appendChild(li);
       });
     };
+  </script>
+  <script>
+    const printLink = document.createElement('link');
+    printLink.rel = 'stylesheet';
+    printLink.href = '/static/css/print.css';
+    printLink.media = 'print';
+    document.head.appendChild(printLink);
   </script>
   <script type="module" src="/static/js/app.js"></script>
 </body>

--- a/tests/e2e/print_visibility.spec.ts
+++ b/tests/e2e/print_visibility.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+test('header and toolbar buttons hidden when printing', async ({ page }) => {
+  await page.goto('/');
+
+  const header = page.locator('header');
+  await expect(header).toBeVisible();
+
+  const buttons = header.locator('button');
+  await expect(buttons).toHaveCount(3);
+  for (let i = 0; i < 3; i++) {
+    await expect(buttons.nth(i)).toBeVisible();
+  }
+
+  await page.emulateMedia({ media: 'print' });
+
+  await expect(header).toBeHidden();
+  for (let i = 0; i < 3; i++) {
+    await expect(buttons.nth(i)).toBeHidden();
+  }
+});


### PR DESCRIPTION
## Summary
- inject `print.css` dynamically so it loads after Tailwind
- add e2e test to verify header and toolbar buttons disappear in print view

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun is required)*
- `npx playwright test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686c6b0bd88c832d977b7c3a86c38751