### PR TITLE
Move service worker path

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -661,7 +661,7 @@ document.addEventListener('DOMContentLoaded', applyContrastClasses);   // â† ã‚
 
 // Service Worker registration
 if ("serviceWorker" in navigator) {
-  navigator.serviceWorker.register("/static/js/sw.js", { scope: "/" })
+  navigator.serviceWorker.register("/static/sw.js", { scope: "/" })
     .then(reg => console.log("SW registered:", reg.scope))
     .catch(err => console.error("SW registration failed:", err));
 }

--- a/schedule_app/static/sw.js
+++ b/schedule_app/static/sw.js
@@ -3,7 +3,7 @@ const CACHE_URLS = [
   '/',
   '/static/css/styles.css',
   '/static/js/app.js',
-  '/static/js/sw.js',
+  '/static/sw.js',
   '/manifest.json',
   '/icon-192.png',
 ];


### PR DESCRIPTION
## Summary
- move `sw.js` from `/static/js` to `/static`
- update service worker URL in the cache list
- register the worker from `/static/sw.js` with scope `/`

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c7536fcc4832dbd54442703612f24