### PR TITLE
Add root service worker route

### DIFF
--- a/schedule_app/__init__.py
+++ b/schedule_app/__init__.py
@@ -115,6 +115,15 @@ def create_app(*, testing: bool = False) -> Flask:  # type: ignore[name-defined]
         local_tw = os.getenv("LOCAL_TW") == "1"
         return render_template("index.html", local_tw=local_tw)
 
+    @app.get("/sw.js")
+    def service_worker():
+        """Return the service worker script."""
+        from flask import current_app
+
+        resp = current_app.send_static_file("sw.js")
+        resp.headers["Service-Worker-Allowed"] = "/"
+        return resp
+
     @app.get("/login")
     def login():
         """Begin the OAuth2 PKCE flow and redirect the user."""

--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -661,7 +661,7 @@ document.addEventListener('DOMContentLoaded', applyContrastClasses);   // â† ã‚
 
 // Service Worker registration
 if ("serviceWorker" in navigator) {
-  navigator.serviceWorker.register("/static/sw.js", { scope: "/" })
+  navigator.serviceWorker.register("/sw.js", { scope: "/" })
     .then(reg => console.log("SW registered:", reg.scope))
     .catch(err => console.error("SW registration failed:", err));
 }

--- a/tests/e2e/service_worker.spec.ts
+++ b/tests/e2e/service_worker.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+// Ensure the service worker registers and becomes active
+
+test('service worker registration', async ({ page }) => {
+  await page.goto('/');
+
+  await page.waitForFunction(() => navigator.serviceWorker.controller !== null);
+
+  const hasController = await page.evaluate(() => !!navigator.serviceWorker.controller);
+  expect(hasController).toBe(true);
+});


### PR DESCRIPTION
## Summary
- serve `sw.js` from a dedicated `/sw.js` endpoint
- register the service worker from the root path
- add Playwright test verifying the worker becomes active

## Testing
- `pytest -q` *(fails: freezegun missing)*
- `npx playwright test tests/e2e/service_worker.spec.ts --reporter=list` *(fails: cannot download playwright)*

------
https://chatgpt.com/codex/tasks/task_e_686c796773bc832db260376e1d02aa36