### PR TITLE
Add Service Worker Allowed header

### DIFF
--- a/schedule_app/__init__.py
+++ b/schedule_app/__init__.py
@@ -85,6 +85,12 @@ def create_app(*, testing: bool = False) -> Flask:  # type: ignore[name-defined]
     # Lightweight Google API client stub
     app.extensions["gclient"] = GoogleClient(credentials=None)
 
+    @app.after_request
+    def _allow_service_worker(response):
+        if request.path == "/static/sw.js":
+            response.headers["Service-Worker-Allowed"] = "/"
+        return response
+
     if testing:
         app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
 


### PR DESCRIPTION
## Summary
- attach `after_request` handler in app factory to set `Service-Worker-Allowed` header
- keep service worker registration code unchanged

## Testing
- `ruff check schedule_app/__init__.py`
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c7d34281c832dbe11c2aacfcecc4f