### PR TITLE
Add CSS precaching in Service Worker

### DIFF
--- a/schedule_app/static/sw.js
+++ b/schedule_app/static/sw.js
@@ -2,14 +2,19 @@ const CACHE_NAME = 'schedule-app-v1';
 const CACHE_URLS = [
   '/',
   '/static/css/styles.css',
+  '/static/css/a11y.css',
+  '/static/css/print.css',
+  '/static/css/tailwind.min.css',
   '/static/js/app.js',
   '/static/sw.js',
   '/manifest.json',
   '/icon-192.png',
 ];
 
-self.addEventListener('install', () => {
-  // Cache will be populated on-demand during fetch events
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(CACHE_URLS)),
+  );
 });
 
 self.addEventListener('activate', (event) => {


### PR DESCRIPTION
## Summary
- precache all local CSS files during service worker install
- ensure offline mode serves styles from cache

## Testing
- `ruff check schedule_app/static/sw.js` *(fails: SyntaxError because ruff expects Python)*
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c7faf0248832d8a06328f755bef60