### PR TITLE
Add CSS precaching in Service Worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ pytest -q
 
 ### Playwright offline mode
 
-When network access is restricted (e.g. CI), set `LOCAL_TW=1` so the app uses
-`static/css/tailwind.min.css` instead of the CDN script. Playwright will then
-run entirely offline with `npx playwright test`.
+The app uses `static/css/tailwind.min.css` by default so tests can run offline.
+Set `LOCAL_TW=0` to load the Tailwind CDN script instead.
+Playwright will then run entirely offline with `npx playwright test`.
 
 
 ## Tasks API

--- a/schedule_app/__init__.py
+++ b/schedule_app/__init__.py
@@ -118,7 +118,9 @@ def create_app(*, testing: bool = False) -> Flask:  # type: ignore[name-defined]
     @app.get("/")
     def index():
         """Render the main page with optional local Tailwind."""
-        local_tw = os.getenv("LOCAL_TW") == "1"
+        # Use local Tailwind by default so offline mode still has styles.
+        # Set LOCAL_TW=0 to load the CDN script instead.
+        local_tw = os.getenv("LOCAL_TW", "1") != "0"
         return render_template("index.html", local_tw=local_tw)
 
     @app.get("/login")

--- a/schedule_app/static/sw.js
+++ b/schedule_app/static/sw.js
@@ -2,14 +2,19 @@ const CACHE_NAME = 'schedule-app-v1';
 const CACHE_URLS = [
   '/',
   '/static/css/styles.css',
+  '/static/css/a11y.css',
+  '/static/css/print.css',
+  '/static/css/tailwind.min.css',
   '/static/js/app.js',
   '/static/sw.js',
   '/manifest.json',
   '/icon-192.png',
 ];
 
-self.addEventListener('install', () => {
-  // Cache will be populated on-demand during fetch events
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(CACHE_URLS)),
+  );
 });
 
 self.addEventListener('activate', (event) => {


### PR DESCRIPTION
## Summary
- precache all local CSS files during service worker install
- ensure offline mode serves styles from cache
- use local Tailwind CSS by default

## Testing
- `ruff check schedule_app/static/sw.js` *(fails: SyntaxError because ruff expects Python)*
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c7faf0248832d8a06328f755bef60