### PR TITLE
Update PWA icon path

### DIFF
--- a/schedule_app/static/manifest.json
+++ b/schedule_app/static/manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "1-Day Schedule",
+  "short_name": "Schedule",
+  "start_url": "/?source=pwa",
+  "display": "standalone",
+  "theme_color": "#2563EB",
+  "background_color": "#FFFFFF",
+  "icons": [
+    { "src": "/static/icon-192.png", "sizes": "192x192", "type": "image/png" }
+  ]
+}

--- a/schedule_app/static/sw.js
+++ b/schedule_app/static/sw.js
@@ -8,7 +8,7 @@ const CACHE_URLS = [
   '/static/js/app.js',
   '/static/sw.js',
   '/manifest.json',
-  '/icon-192.png',
+  '/static/icon-192.png',
 ];
 
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
## Summary
- add missing manifest.json
- cache the icon under `/static` in the service worker

## Testing
- `pre-commit run --files schedule_app/static/manifest.json schedule_app/static/sw.js` *(fails: command not found)*
- `pytest -q` *(fails: Skipped: freezegun is required to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_686c88e5f96c832d8454374ce31bd473