### PR TITLE
Fix offline CSS by removing Tailwind CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ pytest -q
 
 ### Playwright offline mode
 
-When network access is restricted (e.g. CI), set `LOCAL_TW=1` so the app uses
-`static/css/tailwind.min.css` instead of the CDN script. Playwright will then
-run entirely offline with `npx playwright test`.
+The application ships with Tailwind CSS in `static/css/tailwind.min.css` so
+tests run without network access. Simply execute `npx playwright test` and the
+Service Worker will serve the cached styles when offline.
 
 
 ## Tasks API

--- a/schedule_app/__init__.py
+++ b/schedule_app/__init__.py
@@ -117,9 +117,8 @@ def create_app(*, testing: bool = False) -> Flask:  # type: ignore[name-defined]
     # 暫定トップページ
     @app.get("/")
     def index():
-        """Render the main page with optional local Tailwind."""
-        local_tw = os.getenv("LOCAL_TW") == "1"
-        return render_template("index.html", local_tw=local_tw)
+        """Render the main page."""
+        return render_template("index.html")
 
     @app.get("/login")
     def login():

--- a/schedule_app/static/sw.js
+++ b/schedule_app/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'schedule-app-v1';
+const CACHE_NAME = 'schedule-app-v2';
 const CACHE_URLS = [
   '/',
   '/static/css/styles.css',
@@ -35,26 +35,6 @@ self.addEventListener('fetch', (event) => {
   const { request } = event;
   if (request.method !== 'GET') return;
   const url = new URL(request.url);
-
-  // ---------------------------------------------------------------------
-  // Fallback for Tailwind CDN script. When offline, replace the external
-  // script with a local CSS file to maintain styling.
-  // ---------------------------------------------------------------------
-  if (url.hostname === 'cdn.tailwindcss.com') {
-    event.respondWith(
-      fetch(request).catch(() =>
-        caches.match('/static/css/tailwind.min.css').then((resp) => {
-          if (!resp) return new Response('', { status: 404 });
-          const js =
-            "(function(){var l=document.createElement('link');l.rel='stylesheet';l.href='/static/css/tailwind.min.css';document.head.appendChild(l);})();";
-          return new Response(js, {
-            headers: { 'Content-Type': 'application/javascript' },
-          });
-        })
-      )
-    );
-    return;
-  }
 
   if (url.origin !== location.origin) return;
 

--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -1,11 +1,7 @@
 <!doctype html>
 <html>
 <head>
-{% if local_tw %}
 <link rel="stylesheet" href="/static/css/tailwind.min.css">
-{% else %}
-<script src="https://cdn.tailwindcss.com?plugins=typography"></script>
-{% endif %}
 <link rel="stylesheet" href="/static/css/styles.css">
 <link rel="stylesheet" href="/static/css/a11y.css">
 </head>


### PR DESCRIPTION
## Summary
- drop `LOCAL_TW` check and always use bundled Tailwind CSS
- clean up README instructions for offline Playwright usage
- remove CDN fallback logic from the service worker and bump cache version

## Testing
- `pytest -q` *(fails: freezegun missing)*
- `npx playwright test` *(fails: npm install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686c8c5883a4832da22a4412cca87cb1