### PR TITLE
Add offline Tailwind CSS

### DIFF
--- a/schedule_app/static/css/tailwind.min.css
+++ b/schedule_app/static/css/tailwind.min.css
@@ -1,1 +1,86 @@
-/* Tailwind CSS offline build (truncated) */
+/* Minimal Tailwind subset for offline use */
+.grid{display:grid}
+.flex{display:flex}
+.inline{display:inline}
+.inline-flex{display:inline-flex}
+.items-center{align-items:center}
+.flex-1{flex:1 1 0%}
+.flex-nowrap{flex-wrap:nowrap}
+.shrink-0{flex-shrink:0}
+.sticky{position:sticky}
+.fixed{position:fixed}
+.top-0{top:0}
+.top-14{top:3.5rem}
+.left-1/2{left:50%}
+.bottom-4{bottom:1rem}
+.-translate-x-1/2{transform:translateX(-50%)}
+.z-10{z-index:10}
+.z-20{z-index:20}
+.z-50{z-index:50}
+.border{border:1px solid #d1d5db}
+.border-b{border-bottom:1px solid #d1d5db}
+.border-r{border-right:1px solid #d1d5db}
+.border-gray-200{border-color:#e5e7eb}
+.border-gray-300{border-color:#d1d5db}
+.rounded{border-radius:0.25rem}
+.rounded-full{border-radius:9999px}
+.p-1{padding:0.25rem}
+.p-2{padding:0.5rem}
+.p-4{padding:1rem}
+.px-2{padding-left:0.5rem;padding-right:0.5rem}
+.px-3{padding-left:0.75rem;padding-right:0.75rem}
+.px-4{padding-left:1rem;padding-right:1rem}
+.py-1{padding-top:0.25rem;padding-bottom:0.25rem}
+.py-2{padding-top:0.5rem;padding-bottom:0.5rem}
+.pr-4{padding-right:1rem}
+.ml-2{margin-left:0.5rem}
+.gap-1{gap:0.25rem}
+.gap-2{gap:0.5rem}
+.gap-4{gap:1rem}
+.w-4{width:1rem}
+.h-4{height:1rem}
+.w-60{width:15rem}
+.text-right{text-align:right}
+.text-sm{font-size:0.875rem;line-height:1.25rem}
+.text-xs{font-size:0.75rem;line-height:1rem}
+.text-white{color:#fff}
+.text-gray-400{color:#9ca3af}
+.text-gray-500{color:#6b7280}
+.text-blue-800{color:#1e40af}
+.bg-white{background-color:#fff}
+.bg-blue-50{background-color:#eff6ff}
+.bg-blue-100{background-color:#dbeafe}
+.bg-blue-500{background-color:#3b82f6}
+.bg-blue-600{background-color:#2563eb}
+.bg-blue-700{background-color:#1d4ed8}
+.bg-gray-50{background-color:#f9fafb}
+.bg-gray-200{background-color:#e5e7eb}
+.bg-green-200{background-color:#bbf7d0}
+.bg-red-300{background-color:#fca5a5}
+.bg-red-600{background-color:#dc2626}
+.shadow{box-shadow:0 1px 2px rgb(0 0 0 / 0.1)}
+.shadow-lg{box-shadow:0 10px 15px rgb(0 0 0 / 0.1)}
+.cursor-grab{cursor:grab}
+.cursor-pointer{cursor:pointer}
+.cursor-not-allowed{cursor:not-allowed}
+.select-none{user-select:none}
+.whitespace-nowrap{white-space:nowrap}
+.scrollbar-thin{scrollbar-width:thin}
+.opacity-0{opacity:0}
+.opacity-50{opacity:0.5}
+.transition-opacity{transition-property:opacity}
+.duration-300{transition-duration:.3s}
+.grid-cols-[70px_1fr]{grid-template-columns:70px 1fr}
+.space-y-2> :not([hidden])~:not([hidden]){margin-top:0.5rem}
+/* Ring utilities */
+.ring-2{box-shadow:0 0 0 2px var(--tw-ring-color,#3b82f6)}
+.ring-blue-400{--tw-ring-color:#60a5fa}
+.ring-red-500{--tw-ring-color:#ef4444}
+.focus-visible\:ring-2:focus-visible{box-shadow:0 0 0 2px var(--tw-ring-color,#3b82f6)}
+.focus-visible\:ring-blue-400:focus-visible{--tw-ring-color:#60a5fa}
+.focus-visible\:outline-none:focus-visible{outline:2px solid transparent;outline-offset:2px}
+.hover\:bg-blue-50:hover{background-color:#eff6ff}
+.hover\:bg-gray-50:hover{background-color:#f9fafb}
+.hover\:bg-blue-700:hover{background-color:#1d4ed8}
+.active\:translate-y-0.5:active{transform:translateY(0.125rem)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}


### PR DESCRIPTION
## Summary
- embed a tiny offline Tailwind build that includes the classes used in the templates
- keep ring and layout utilities so focus styling and grid layout work without the CDN

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun missing)*
- `npx playwright test` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686c8eaf6398832db4f19abfcf26a61d