### PR TITLE
Update manifest cache path

### DIFF
--- a/schedule_app/static/sw.js
+++ b/schedule_app/static/sw.js
@@ -7,7 +7,7 @@ const CACHE_URLS = [
   '/static/css/tailwind.min.css',
   '/static/js/app.js',
   '/static/sw.js',
-  '/manifest.json',
+  '/static/manifest.json',
   '/static/icon-192.png',
 ];
 


### PR DESCRIPTION
## Summary
- cache the manifest in the service worker from `/static/manifest.json`

## Testing
- `pip install -r requirements.dev.txt` *(fails: Could not find a version that satisfies the requirement flask==2.3.*)*
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_686c9018e410832d940041ad84516552