### PR TITLE
Fix missing icon references

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -295,9 +295,7 @@ jobs:
   "display": "standalone",
   "theme_color": "#2563EB",
   "background_color": "#FFFFFF",
-  "icons": [
-    { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" }
-  ]
+  "icons": []
 }
 ```
 

--- a/schedule_app/static/manifest.json
+++ b/schedule_app/static/manifest.json
@@ -5,7 +5,5 @@
   "display": "standalone",
   "theme_color": "#2563EB",
   "background_color": "#FFFFFF",
-  "icons": [
-    { "src": "/static/icon-192.png", "sizes": "192x192", "type": "image/png" }
-  ]
+  "icons": []
 }

--- a/schedule_app/static/sw.js
+++ b/schedule_app/static/sw.js
@@ -8,7 +8,6 @@ const CACHE_URLS = [
   '/static/js/app.js',
   '/static/sw.js',
   '/static/manifest.json',
-  '/static/icon-192.png',
 ];
 
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
## Summary
- prevent 404s from non-existent PWA icons

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_686c91111c08832d9fa078b8dc8d118d