### PR TITLE
Switch schedule/generate to GET

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ All datetimes are UTC RFC 3339 strings. Validation errors return a 422 response 
 
 | Method | Path | Description |
 | ------ | ---- | ----------- |
-| POST | `/api/schedule/generate` | Generate a schedule grid for one day |
+| GET | `/api/schedule/generate` | Generate a schedule grid for one day |
 
 `date` is a required query parameter that accepts an ISO‑8601 datetime
 (e.g. `2025-01-01T09:00:00+09:00`) or `YYYY-MM-DD`. When the value lacks a

--- a/SPEC.md
+++ b/SPEC.md
@@ -119,7 +119,7 @@ class Block:
 | POST   | `/api/blocks`                                                   | 201 Block    | 422                         |
 | PUT    | `/api/blocks/{id}`                                              | 200 Block    | 404 / 422                   |
 | DELETE | `/api/blocks/{id}`                                              | 204          | 404                         |
-| POST   | `/api/schedule/generate?date=YYYY‑MM‑DD` | 200 Schedule | 400 / 422                   |
+| GET    | `/api/schedule/generate?date=YYYY‑MM‑DD` | 200 Schedule | 400 / 422                   |
 
 *`date` は ISO‑8601 日時 (例: `2025-01-01T09:00:00+09:00`) または `YYYY‑MM‑DD` を受け付ける。タイムゾーンを含まない場合は `TIMEZONE` 環境変数で指定されたゾーン（既定 `cfg.TIMEZONE`）として解釈し、エンドポイントはこの JST 日付をサービス層へそのまま渡し、サービス側で UTC へ変換する。*
 *Google Calendar API が失敗した場合は 502 Bad Gateway として応答する。*

--- a/schedule_app/api/schedule.py
+++ b/schedule_app/api/schedule.py
@@ -9,7 +9,7 @@ bp = Blueprint("schedule", __name__, url_prefix="/api/schedule")
 schedule_bp = bp
 
 
-@bp.route("/generate", methods=["POST", "GET"])
+@bp.route("/generate", methods=["GET"])
 def generate_schedule():  # noqa: D401 - simple endpoint
     """Generate a schedule grid for the specified date."""
     date_str = request.args.get("date")

--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -414,7 +414,6 @@ function saveState() {
 async function loadGridFromServer(date) {
   const res = await fetch(
     `/api/schedule/generate?date=${date}&algo=greedy`,
-    { method: 'POST' },
   );
 
   if (!res.ok) {

--- a/tests/e2e/generate_button.spec.ts
+++ b/tests/e2e/generate_button.spec.ts
@@ -13,5 +13,5 @@ test('generate button triggers schedule API', async ({ page }) => {
     page.getByTestId('generate-btn').click()
   ]);
 
-  expect(req.method()).toBe('POST');
+  expect(req.method()).toBe('GET');
 });

--- a/tests/integration/test_schedule_api.py
+++ b/tests/integration/test_schedule_api.py
@@ -24,7 +24,7 @@ def client(app: Flask):
 
 
 def test_generate_simple(client) -> None:
-    resp = client.post("/api/schedule/generate?date=2025-01-01")
+    resp = client.get("/api/schedule/generate?date=2025-01-01")
     assert resp.status_code == 200
     data = resp.get_json()
     assert isinstance(data, dict)
@@ -34,7 +34,7 @@ def test_generate_simple(client) -> None:
 
 
 def test_generate_accepts_z_datetime(client) -> None:
-    resp = client.post("/api/schedule/generate?date=2025-01-01T00:00:00Z")
+    resp = client.get("/api/schedule/generate?date=2025-01-01T00:00:00Z")
     assert resp.status_code == 200
     data = resp.get_json()
     assert isinstance(data, dict)
@@ -42,7 +42,7 @@ def test_generate_accepts_z_datetime(client) -> None:
 
 
 def test_generate_accepts_naive_datetime(client) -> None:
-    resp = client.post("/api/schedule/generate?date=2025-01-01T00:00:00")
+    resp = client.get("/api/schedule/generate?date=2025-01-01T00:00:00")
     assert resp.status_code == 200
     data = resp.get_json()
     assert isinstance(data, dict)
@@ -50,7 +50,7 @@ def test_generate_accepts_naive_datetime(client) -> None:
 
 
 def test_generate_naive_datetime_midday(client) -> None:
-    resp = client.post("/api/schedule/generate?date=2025-07-05T15:00:00")
+    resp = client.get("/api/schedule/generate?date=2025-07-05T15:00:00")
     assert resp.status_code == 200
     data = resp.get_json()
     assert isinstance(data, dict)


### PR DESCRIPTION
## Summary
- make the schedule generation endpoint accept only GET
- update js fetch calls
- adjust docs for GET method
- fix tests to use GET

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q tests/integration/test_schedule_api.py` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_686c95c81818832da09963c6f9b074b1