### PR TITLE
Improve offline fallback in service worker

### DIFF
--- a/schedule_app/static/sw.js
+++ b/schedule_app/static/sw.js
@@ -69,6 +69,8 @@ self.addEventListener('fetch', (event) => {
           .match(request)
           .then((cached) => cached || networkResponse);
       })
-      .catch(() => caches.match(request))
+      .catch((err) =>
+        caches.match(request).then((r) => r || Promise.reject(err))
+      )
   );
 });


### PR DESCRIPTION
## Summary
- update `sw.js` to return cache fallback and reject if no cache match

## Testing
- `pytest -q` *(fails: freezegun is required)*
- `npx playwright test` *(fails: npm registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686c9a0516a4832db25f1f182df7713e