### PR TITLE
Fix duplicate todayUtcISO function

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -22,14 +22,6 @@ export function todayUtcISO() {
 }
 
 (async () => {
-  /** YYYY-MM-DD (UTC) を返す */
-  function todayUtcISO() { // DEPRECATED: moved to module scope
-    const d = new Date();
-    const y = d.getUTCFullYear();
-    const m = String(d.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(d.getUTCDate()).padStart(2, "0");
-    return `${y}-${m}-${day}`;
-  }
 
   /** Event[] を取得 */
   async function fetchEvents(dateStr) {


### PR DESCRIPTION
## Summary
- remove the deprecated `todayUtcISO` defined inside the startup IIFE
- calls now use the exported module-scope `todayUtcISO`

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_686caa48772c832d9cd5c0b5ab62d4b1