### PR TITLE
Fix offline event block rendering

### DIFF
--- a/schedule_app/services/schedule.py
+++ b/schedule_app/services/schedule.py
@@ -171,6 +171,13 @@ def generate_schedule(target_day: date, *, algo: str = "greedy") -> dict:
             "title": ev.title,
             "start_utc": _iso(ev.start_utc),
             "end_utc": _iso(ev.end_utc),
+            "start_slot": max(
+                _to_index(quantize(ev.start_utc, up=False), base=start_utc), 0
+            ),
+            "end_slot": min(
+                _to_index(quantize(ev.end_utc, up=True), base=start_utc) - 1,
+                DAY_SLOTS - 1,
+            ),
             "color": "bg-gray-200",
         }
         for ev in events
@@ -193,6 +200,8 @@ def generate_schedule(target_day: date, *, algo: str = "greedy") -> dict:
             "category": t.category,
             "start_utc": _iso(start) if start else None,
             "end_utc": _iso(end) if end else None,
+            "start_slot": min(idxs) if idxs else None,
+            "end_slot": max(idxs) if idxs else None,
             "color": "bg-green-200",
         }
 

--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -402,7 +402,30 @@ function renderGrid() {
     }
     if (type === 1 || type === 2) el.classList.add('grid-slot--busy');
     if (meta && meta.title) el.textContent = meta.title;
+    el.classList.remove('border-t-0', 'border-b-0');
   });
+
+  function groupBlocks(metaMap) {
+    Object.values(metaMap || {}).forEach((m) => {
+      const s = Number(m.start_slot);
+      const e = Number(m.end_slot);
+      if (!Number.isInteger(s) || !Number.isInteger(e)) return;
+      for (let i = s; i <= e; i++) {
+        const slot = document.querySelector(`[data-slot-index="${i}"]`);
+        if (!slot) continue;
+        if (i === s) {
+          slot.textContent = m.title || '';
+        } else {
+          slot.textContent = '';
+          slot.classList.add('border-t-0');
+        }
+        if (i < e) slot.classList.add('border-b-0');
+      }
+    });
+  }
+
+  groupBlocks(scheduleMeta.events);
+  groupBlocks(scheduleMeta.tasks);
   /* Reduced-contrast ON なら新セルにも busy-strong を再付与 */
   applyContrastClasses();
 }


### PR DESCRIPTION
## Summary
- save start_slot/end_slot info in schedule metadata
- group adjacent slots into single blocks when rendering

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686cb7e1568c832da494671ee6369b61