### PR TITLE
Ensure event meta color persists offline

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -485,6 +485,25 @@ async function loadGridFromServer(date) {
       if (rec && rec.grid) {
         scheduleMeta = rec.meta || { tasks: {}, events: {} };
         scheduleGrid = rec.grid.slice();
+
+        // ───── reconstruct missing event metadata ─────
+        if (!scheduleMeta.events || Object.keys(scheduleMeta.events).length === 0) {
+          const events = {};
+          for (let i = 0; i < scheduleGrid.length; i++) {
+            const cell = scheduleGrid[i];
+            if (typeof cell === 'object' && cell.event_id) {
+              const id = cell.event_id;
+              if (!events[id]) {
+                events[id] = { id, start_slot: i, end_slot: i, color: 'bg-gray-200' };
+              } else {
+                events[id].end_slot = i;
+              }
+            }
+          }
+          scheduleMeta.events = events;
+          saveState();
+        }
+
         renderGrid();
         return { grid: scheduleGrid, unplaced: [] };
       }


### PR DESCRIPTION
## Summary
- reconstruct missing event metadata from saved grid
- include default gray color when rebuilding events
- persist updated meta in IndexedDB

## Testing
- `npx playwright test` *(fails: unable to fetch playwright)*

------
https://chatgpt.com/codex/tasks/task_e_686d1febd370832dbe134c171b316c8a