### PR TITLE
Update Schedule API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,15 +78,21 @@ On success, the endpoint returns `200 OK` with a JSON object:
 ```json
 {
   "date": "2025-01-01",
-  "slots": [0, 1, 2, ...],
+  "slots": [
+    {"busy": true},
+    {"event_id": "abc123"},
+    {"task_id": "t1"},
+    0,
+    ...
+  ],
   "unplaced": []
 }
 ```
 
-`slots` is an array of 144 ten-minute entries where `0` means free, `1` busy and
-`2` occupied by a task. Missing or malformed query parameters yield
-`400 Bad Request`. Invalid task, event or block data returns a `422` problem
-response.
+`slots` is an array of 144 ten-minute entries. `0` indicates free time. An
+object marks busy time and contains either `busy`, `event_id` or `task_id`.
+Missing or malformed query parameters yield `400 Bad Request`. Invalid task,
+event or block data returns a `422` problem response.
 
 
 ## Calendar API

--- a/SPEC.md
+++ b/SPEC.md
@@ -125,13 +125,19 @@ class Block:
 *Google Calendar API が失敗した場合は 502 Bad Gateway として応答する。*
 *認証情報が欠如・期限切れ・取り消しの場合は 401 Unauthorized を返す。*
 *サービス層の `generate_schedule()` は `date`・`algo`・`slots`・`unplaced` を含む辞書を返す。*
-*エンドポイントはその `date`・`slots`・`unplaced` を返し、`slots` の長さは 144 で各要素は `0`（空き）・`1`（busy）・`2`（タスク）を表す整数。*
+*エンドポイントはその `date`・`slots`・`unplaced` を返す。 `slots` は長さ 144 の配列で、`0` は空き時間を表し、オブジェクトはビジー状態を示す。 オブジェクトは `busy` / `event_id` / `task_id` のいずれかのフィールドを持つ。*
 *成功例*
 
 ```json
 {
   "date": "2025-01-01",
-  "slots": [0, 1, 2, ...],
+  "slots": [
+    {"busy": true},
+    {"event_id": "abc123"},
+    {"task_id": "t1"},
+    0,
+    ...
+  ],
   "unplaced": []
 }
 ```


### PR DESCRIPTION
## Summary
- clarify slot entries in README
- explain 0 vs busy/event/task objects
- document same change in SPEC

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_686dae19c974832d8bd32e6bbe90f839