### PR TITLE
Fix stray busy-strong stripes

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -398,7 +398,11 @@ function renderGrid() {
     }
 
     [...el.classList].forEach((cls) => {
-      if (cls.startsWith('bg-') || cls === 'grid-slot--busy') {
+      if (
+        cls.startsWith('bg-') ||
+        cls === 'grid-slot--busy' ||
+        cls === 'busy-strong'
+      ) {
         el.classList.remove(cls);
       }
     });


### PR DESCRIPTION
## Summary
- clear any `.busy-strong` classes when rendering grid slots so old stripes vanish

## Testing
- `pytest -q` *(fails: freezegun missing)*
- `npx playwright test` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686dae25b298832d82e161f40eaefee7