### PR TITLE
Fix offline schedule rendering

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -525,6 +525,9 @@ async function loadGridFromServer(date) {
       : Array.isArray(raw.grid)
         ? raw.grid
         : (() => { throw new Error('Malformed Grid'); })();
+  if (slots.length !== 144) {
+    throw new Error('Incomplete Grid');
+  }
   const unplaced = Array.isArray(raw.unplaced) ? raw.unplaced : [];
 
   scheduleMeta = {


### PR DESCRIPTION
## Summary
- ensure cached schedule responses contain full data

## Testing
- `pytest -q` *(fails: freezegun is required)*
- `npx playwright --version` *(fails: network access restricted)*

------
https://chatgpt.com/codex/tasks/task_e_686db013dc28832da645679969603b04