### PR TITLE
Remove redundant todayUtcISO function

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -22,14 +22,6 @@ export function todayUtcISO() {
 }
 
 (async () => {
-  /** YYYY-MM-DD (UTC) を返す */
-  function todayUtcISO() { // DEPRECATED: moved to module scope
-    const d = new Date();
-    const y = d.getUTCFullYear();
-    const m = String(d.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(d.getUTCDate()).padStart(2, "0");
-    return `${y}-${m}-${day}`;
-  }
 
   /** Event[] を取得 */
   async function fetchEvents(dateStr) {


### PR DESCRIPTION
## Summary
- delete deprecated `todayUtcISO` within the IIFE in `app.js`
- rely on the exported `todayUtcISO` function throughout

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686dfc5b518c832dbf2bbfaf2c4a4a1d