### PR TITLE
Add base Playwright config for e2e tests

### DIFF
--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30000,
+  expect: {
+    timeout: 5000,
+  },
+});


### PR DESCRIPTION
## Summary
- configure Playwright in `tests/e2e/playwright.config.ts` for running e2e tests

## Testing
- `ruff check .`
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f05f7b1cc832db694321e2260ca97