### PR TITLE
Configure Playwright tracing

### DIFF
--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -6,4 +6,8 @@ export default defineConfig({
   expect: {
     timeout: 5000,
   },
+  use: {
+    trace: 'retain-on-failure',
+    headless: true,
+  },
 });


### PR DESCRIPTION
## Summary
- turn on tracing only when tests fail
- run the browser in headless mode for E2E

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_686f0b7e4d04832d848de6e4d928cfcb