### PR TITLE
Add webServer startup for e2e config

### DIFF
--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -9,5 +9,13 @@ export default defineConfig({
   use: {
     trace: 'retain-on-failure',
     headless: true,
+    baseURL: 'http://localhost:5173',
+  },
+  webServer: {
+    command: 'flask --app schedule_app run --port 5173',
+    url: 'http://localhost:5173',
+    timeout: 120 * 1000,
+    env: { GCP_PROJECT: 'dummy-project', GOOGLE_CLIENT_ID: 'dummy-client-id' },
+    reuseExistingServer: !process.env.CI,
   },
 });


### PR DESCRIPTION
## Summary
- start local Flask app when running `tests/e2e` Playwright tests
- wait up to two minutes for the server to be available on port 5173

## Testing
- `npx playwright --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686f0cf57e58832d90c6ebe6038f8a51