### PR TITLE
Add pseudo login helper for Playwright

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,0 +1,16 @@
+import { type Page } from '@playwright/test';
+
+/**
+ * Pseudo login for Playwright tests.
+ *
+ * Skips the Google OAuth flow by inserting a dummy token into
+ * ``sessionStorage`` before any page scripts run.
+ *
+ * @param page   Playwright page instance
+ * @param token  Token value to store (defaults to 'test-token')
+ */
+export async function pseudoLogin(page: Page, token: string = 'test-token'): Promise<void> {
+  await page.addInitScript((value: string) => {
+    window.sessionStorage.setItem('token', value);
+  }, token);
+}


### PR DESCRIPTION
## Summary
- support skipping Google OAuth flow in Playwright tests by adding a helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f0e31ac00832d9db87233819bf8fe