### PR TITLE
Add calendar API mock helper for Playwright tests

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -14,3 +14,25 @@ export async function pseudoLogin(page: Page, token: string = 'test-token'): Pro
     window.sessionStorage.setItem('token', value);
   }, token);
 }
+
+/**
+ * Mock Google Calendar API requests during Playwright tests.
+ *
+ * Intercepts network calls to ``/api/calendar`` and returns ``events``
+ * without contacting the real Google API.
+ *
+ * @param page    Playwright page instance
+ * @param events  Array of event objects to return (defaults to empty array)
+ */
+export async function mockGoogleCalendar(
+  page: Page,
+  events: any[] = [],
+): Promise<void> {
+  await page.route('**/api/calendar**', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(events),
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- expose `mockGoogleCalendar` in `tests/e2e/helpers.ts` to intercept
  `/api/calendar` requests and return predefined events

## Testing
- `pytest -q` *(fails: freezegun is required to run tests)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f0ffa159c832db5416617ac5afd58