### PR TITLE
Add e2e test for homepage title

### DIFF
--- a/tests/e2e/schedule.spec.ts
+++ b/tests/e2e/schedule.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('home page has correct title', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveTitle('1-Day Schedule');
+});


### PR DESCRIPTION
## Summary
- add schedule.spec.ts Playwright test

## Testing
- `npm run test:e2e` *(fails: `playwright` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f17b308b4832d887b18ad52bba518