### PR TITLE
Add task list panel and button

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -122,7 +122,7 @@ async function loadAndRenderTasks() {
     const res   = await fetch('/api/tasks');
     const tasks = await res.json();          // [{id,title,…}, …]
 
-    const pane       = document.getElementById('task-pane');
+    const pane       = document.getElementById('task-list');
     const emptyLabel = document.getElementById('task-empty');
     pane.querySelectorAll('.task-card').forEach((n) => n.remove());
 
@@ -291,7 +291,7 @@ document.addEventListener('DOMContentLoaded', () => {
           markSlot(originIndex, card.dataset.taskId);
         } else {
           // 元は side‑pane にあったカード
-          document.getElementById('task-pane').appendChild(card);
+          document.getElementById('task-list').appendChild(card);
           card.removeAttribute('data-slot-index');
         }
         unmarkSlot(nextIdx);
@@ -479,7 +479,7 @@ function doRedo() {
 
 /** Highlight unplaced tasks and show toast messages. */
 function showUnplacedTasks(unplacedIds) {
-  const pane = document.getElementById('task-pane');
+  const pane = document.getElementById('task-list');
   if (!pane) return;
 
   pane.querySelectorAll('.task-card').forEach((card) => {

--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -27,8 +27,20 @@
     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20"
          fill="currentColor"><path fill-rule="evenodd"
          d="M3 5a1 1 0 011-1h1a1 1 0 011 1v10a1 1 0 01-1 1H4a1 1 0 01-1-1V5zm3.5 5l8-5v10l-8-5z"
-         clip-rule="evenodd" /></svg>
+    clip-rule="evenodd" /></svg>
     Generate
+  </button>
+
+  <!-- Add Task ボタン -->
+  <button
+    id="btn-add-task"
+    type="button"
+    class="inline-flex items-center gap-1 border rounded px-3 py-1
+           bg-green-600 text-white text-sm hover:bg-green-700 active:translate-y-0.5">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z" clip-rule="evenodd" />
+    </svg>
+    Add Task
   </button>
 
   <!-- Undo / Redo Buttons -->
@@ -76,11 +88,12 @@
 <main class="p-4 flex gap-4">
   <!-- ── task side-pane ───────────────────────────────────────────── -->
   <aside id="task-pane"
-         class="w-60 shrink-0 border-r border-gray-300 pr-4 space-y-2 overflow-y-auto"
-         aria-label="Tasks list"
-         role="list">
-    <!-- JS がここに .task-card を挿入 -->
+         class="w-60 shrink-0 border-r border-gray-300 pr-4 overflow-y-auto"
+         aria-label="Tasks list">
     <p id="task-empty" class="text-gray-500 text-sm">タスクがありません</p>
+    <ul id="task-list" class="space-y-2" role="list">
+      <!-- JS がここに .task-card を挿入 -->
+    </ul>
     <template id="task-card-template">
       <div class="task-card p-2 bg-white rounded shadow border cursor-grab select-none hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
            role="listitem" tabindex="0" draggable="true"></div>


### PR DESCRIPTION
## Summary
- create Add Task button in page header
- wrap tasks in `<ul id="task-list">` for better structure
- update client script to append task cards into the new list

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f246a872c832d93bee66e4243bd25