### PR TITLE
Add task modal

### DIFF
--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -113,6 +113,56 @@
     {% endfor %}
   </section>
 </main>
+
+  <!-- タスク追加・編集モーダル -->
+  <dialog id="task-modal" class="p-4 rounded-lg shadow-md">
+    <form id="task-form" method="dialog" class="space-y-2">
+      <input type="hidden" id="task-id" name="id" />
+
+      <label class="block">
+        <span class="text-sm">タイトル</span>
+        <input id="task-title" name="title" type="text"
+               class="border rounded w-full p-1 text-sm" required />
+      </label>
+
+      <label class="block">
+        <span class="text-sm">カテゴリ</span>
+        <input id="task-category" name="category" type="text"
+               class="border rounded w-full p-1 text-sm" />
+      </label>
+
+      <label class="block">
+        <span class="text-sm">所要時間 (分)</span>
+        <input id="task-duration" name="duration" type="number" min="5" step="5"
+               class="border rounded w-full p-1 text-sm" required />
+      </label>
+
+      <label class="block">
+        <span class="text-sm">優先度</span>
+        <select id="task-priority" name="priority"
+                class="border rounded w-full p-1 text-sm">
+          <option value="A">A</option>
+          <option value="B">B</option>
+        </select>
+      </label>
+
+      <label class="block">
+        <span class="text-sm">最速開始時刻</span>
+        <input id="task-earliest" name="earliest_start" type="time"
+               class="border rounded w-full p-1 text-sm" />
+      </label>
+
+      <div class="flex justify-end gap-2 pt-2">
+        <button type="submit"
+                class="border rounded px-3 py-1 text-sm bg-blue-600 text-white hover:bg-blue-700">
+          保存
+        </button>
+        <button type="button" id="task-cancel"
+                class="border rounded px-3 py-1 text-sm">キャンセル</button>
+      </div>
+    </form>
+  </dialog>
+
   <script>
     // ページロード後、IndexedDB もしくは /api/calendar の完了を待って
     // window.renderAllDay(events) が呼ばれる前提。


### PR DESCRIPTION
## Summary
- add a `<dialog>` with form fields for creating/editing tasks

## Testing
- `pytest -q` *(fails: freezegun is required)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f2de7b01c832d8aa9bef59278f76b