### PR TITLE
Add edit support for tasks

### DIFF
--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -89,7 +89,10 @@
     <ul id="task-list" role="list" class="space-y-2"></ul>
     <template id="task-card-template">
       <div class="task-card p-2 bg-white rounded shadow border cursor-grab select-none hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
-           role="listitem" tabindex="0" draggable="true"></div>
+           role="listitem" tabindex="0" draggable="true">
+        <span class="task-label"></span>
+        <button type="button" class="edit-task ml-2 border rounded px-1 text-xs">編集</button>
+      </div>
     </template>
   </aside>
 


### PR DESCRIPTION
## Summary
- add an Edit button to each task card
- prefill modal inputs when editing and send PUT to `/api/tasks/<id>`

## Testing
- `ruff check schedule_app`
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f35c6275c832da94cf1c3b2afad1e