### PR TITLE
Add basic task form validation

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -788,7 +788,20 @@ document.addEventListener('DOMContentLoaded', () => {
     const priEl   = document.getElementById('task-priority');
     const earEl   = document.getElementById('task-earliest');
 
+    const title = titleEl.value.trim();
     const duration = parseInt(durEl.value, 10);
+
+    if (!title) {
+      alert('タイトルを入力してください');
+      titleEl.focus();
+      return;
+    }
+
+    if (!Number.isFinite(duration) || duration % 5 !== 0) {
+      alert('所要時間は5分単位で入力してください');
+      durEl.focus();
+      return;
+    }
 
     const payload = {
       title: titleEl.value,


### PR DESCRIPTION
## Summary
- add simple client-side validation for task form so empty titles or durations not in 5 minute increments show an alert and cancel submit

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f39c4b880832da505faf54ffe97e7