### PR TITLE
Add task CRUD e2e test

### DIFF
--- a/tests/e2e/task_crud.spec.ts
+++ b/tests/e2e/task_crud.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+import { mockGoogleCalendar } from './helpers';
+
+// Task CRUD scenario: create, update and delete via UI
+
+test('task CRUD via modal form', async ({ page, request }) => {
+  // Stub calendar API to avoid 401 redirect
+  await mockGoogleCalendar(page);
+
+  // Remove any existing tasks
+  const existing = await request.get('/api/tasks');
+  const items = await existing.json();
+  for (const t of items) {
+    await request.delete(`/api/tasks/${t.id}`);
+  }
+
+  await page.goto('/');
+
+  // ---- Create a new task ----
+  await page.locator('#btn-add-task').click();
+  await page.fill('#task-title', 'E2E Task');
+  await page.fill('#task-category', 'e2e');
+  await page.fill('#task-duration', '10');
+  await page.selectOption('#task-priority', 'A');
+
+  const [postReq] = await Promise.all([
+    page.waitForRequest(r => r.url().endsWith('/api/tasks') && r.method() === 'POST'),
+    page.locator('#task-form button[type=submit]').click(),
+  ]);
+  expect(postReq.method()).toBe('POST');
+
+  const card = page.locator('.task-card').filter({ hasText: 'E2E Task' });
+  await expect(card).toBeVisible();
+
+  const taskId = await card.getAttribute('data-task-id');
+  expect(taskId).toBeTruthy();
+
+  // ---- Update the task ----
+  await card.locator('.edit-task').click();
+  await page.fill('#task-title', 'Updated Task');
+
+  const [putReq] = await Promise.all([
+    page.waitForRequest(r => r.url().includes(`/api/tasks/${taskId}`) && r.method() === 'PUT'),
+    page.locator('#task-form button[type=submit]').click(),
+  ]);
+  expect(putReq.method()).toBe('PUT');
+  await expect(card).toContainText('Updated Task');
+
+  // ---- Delete the task ----
+  page.once('dialog', d => d.accept());
+  const [delReq] = await Promise.all([
+    page.waitForRequest(r => r.url().includes(`/api/tasks/${taskId}`) && r.method() === 'DELETE'),
+    card.locator('.delete-task').click(),
+  ]);
+  expect(delReq.method()).toBe('DELETE');
+  await expect(page.locator(`[data-task-id="${taskId}"]`)).toHaveCount(0);
+});
+

--- a/tests/e2e/task_crud.spec.ts
+++ b/tests/e2e/task_crud.spec.ts
@@ -44,13 +44,14 @@ test('task CRUD via modal form', async ({ page, request }) => {
     page.locator('#task-form button[type=submit]').click(),
   ]);
   expect(putReq.method()).toBe('PUT');
-  await expect(card).toContainText('Updated Task');
+  const updated = page.locator(`[data-task-id="${taskId}"]`);
+  await expect(updated).toContainText('Updated Task');
 
   // ---- Delete the task ----
   page.once('dialog', d => d.accept());
   const [delReq] = await Promise.all([
     page.waitForRequest(r => r.url().includes(`/api/tasks/${taskId}`) && r.method() === 'DELETE'),
-    card.locator('.delete-task').click(),
+    updated.locator('.delete-task').click(),
   ]);
   expect(delReq.method()).toBe('DELETE');
   await expect(page.locator(`[data-task-id="${taskId}"]`)).toHaveCount(0);


### PR DESCRIPTION
## Summary
- add a Playwright scenario that exercises task creation, update and deletion

## Testing
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f3e181934832da78bc4d000a56b20