### PR TITLE
Add undo-redo assertion

### DIFF
--- a/tests/e2e/undo_redo.spec.ts
+++ b/tests/e2e/undo_redo.spec.ts
@@ -71,9 +71,11 @@ test('Undo/Redo 動作確認', async ({ page }) => {
   /* --- Undo / Redo --- */
   await page.keyboard.press('Control+Z');
 
+  // Slot should no longer contain the task after undo
+  await expect(slotAfter.locator(selector)).toHaveCount(0);
   await expect(slotBefore.locator(selector)).toHaveCount(0);
 
-  // 🔴ここを実際のDOMに合わせて変更してください
+  // Card should return to the side panel
   const sidePanel = page.locator('#task-pane');
   await expect(sidePanel.locator(selector)).toHaveCount(1);
 


### PR DESCRIPTION
## Summary
- update `undo_redo` test to assert the slot is empty after undo
- replace placeholder comment with explanation about side panel

## Testing
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f46b03e94832db4e7813327877f02