### PR TITLE
Implement all-day event filter

### DIFF
--- a/schedule_app/services/google_client.py
+++ b/schedule_app/services/google_client.py
@@ -166,7 +166,48 @@ class GoogleClient:
             time_max=end.isoformat().replace("+00:00", "Z"),
         )
 
-        return [self._to_event(item) for item in items]
+        target_day = local_start.date()
+        events: list[Event] = []
+        for item in items:
+            start_info = item.get("start", {})
+            end_info = item.get("end", {})
+            start_date_raw = start_info.get("date")
+            end_date_raw = end_info.get("date")
+            if not (start_date_raw or end_date_raw):
+                continue
+
+            start_date = (
+                datetime.fromisoformat(start_date_raw).date()
+                if start_date_raw
+                else target_day
+            )
+            end_date = (
+                datetime.fromisoformat(end_date_raw).date()
+                if end_date_raw
+                else None
+            )
+
+            include = False
+            if end_date is not None:
+                if start_date <= target_day < end_date:
+                    include = True
+            else:
+                if start_date == target_day:
+                    include = True
+
+            if include:
+                ev = self._to_event(item)
+                events.append(
+                    Event(
+                        id=ev.id,
+                        start_utc=ev.start_utc,
+                        end_utc=ev.end_utc,
+                        title=ev.title,
+                        all_day=True,
+                    )
+                )
+
+        return events
 
 
 __all__ = ["GoogleClient", "GoogleAPIUnauthorized", "APIError", "SCOPES"]

--- a/tests/unit/test_google_client_list.py
+++ b/tests/unit/test_google_client_list.py
@@ -28,8 +28,8 @@ def test_list_events_dataclass(monkeypatch):
     sample = {
         "id": "1",
         "summary": "Demo",
-        "start": {"dateTime": "2025-01-01T01:00:00Z"},
-        "end": {"dateTime": "2025-01-01T02:00:00Z"},
+        "start": {"date": "2025-01-01"},
+        "end": {"date": "2025-01-02"},
     }
 
     def fake_fetch(*, time_min: str, time_max: str):
@@ -43,8 +43,8 @@ def test_list_events_dataclass(monkeypatch):
     assert isinstance(ev, Event)
     assert ev.id == "1"
     assert ev.title == "Demo"
-    assert ev.start_utc == datetime(2025, 1, 1, 1, 0, tzinfo=timezone.utc)
-    assert ev.end_utc == datetime(2025, 1, 1, 2, 0, tzinfo=timezone.utc)
+    assert ev.start_utc == datetime(2025, 1, 1, 0, 0, tzinfo=timezone.utc)
+    assert ev.end_utc == datetime(2025, 1, 2, 0, 0, tzinfo=timezone.utc)
 
 
 def test_list_events_all_day_filter(monkeypatch):


### PR DESCRIPTION
## Summary
- filter Google Calendar events so only all-day items for the selected date are returned
- test that list_events keeps only all-day events

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f49006d8c832d8383bba81bc87868