### PR TITLE
Filter all-day events in front-end

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -67,6 +67,16 @@ export function todayUtcISO() {
   return `${y}-${m}-${day}`;
 }
 
+/**
+ * Extract only all-day events from an array.
+ *
+ * @param {Array<{all_day?: boolean}>} events
+ * @returns {any[]}
+ */
+export function filterAllDay(events) {
+  return (events || []).filter(ev => ev.all_day);
+}
+
 (async () => {
 
   /** Event[] を取得 */
@@ -76,7 +86,9 @@ export function todayUtcISO() {
 
   try {
     const events = await fetchEvents(todayUtcISO());
-    window.renderAllDay(events);
+    const allDay = filterAllDay(events);
+    window.allDayEvents = allDay;
+    window.renderAllDay(allDay);
   } catch (err) {
     console.error(err);
   }
@@ -656,7 +668,9 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!ymd) return;
     try {
       const events = await apiFetch(`/api/calendar?date=${ymd}`);
-      window.renderAllDay(events);
+      const allDay = filterAllDay(events);
+      window.allDayEvents = allDay;
+      window.renderAllDay(allDay);
     } catch (err) {
       console.error('[calendar] reload failed', err);
     }
@@ -676,7 +690,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
       /* 2) All-day 予定も最新化 */
       const events = await apiFetch(`/api/calendar?date=${ymd}`);
-      window.renderAllDay(events);
+      const allDay = filterAllDay(events);
+      window.allDayEvents = allDay;
+      window.renderAllDay(allDay);
     } catch (err) {
       console.error(err);
       alert(`スケジュール生成に失敗しました\n${err.message ?? err}`);

--- a/tests/e2e/schedule.spec.ts
+++ b/tests/e2e/schedule.spec.ts
@@ -9,18 +9,25 @@ test('top page loads with correct title', async ({ page }) => {
 test('page shows logged-in state after pseudo login and reload', async ({ page }) => {
   await mockGoogleCalendar(page, [
     {
-      id: 'ev1',
+      id: 'ev0',
       start_utc: '2025-01-01T09:00:00Z',
       end_utc: '2025-01-01T10:00:00Z',
-      title: 'Sample Event',
+      title: 'Timed Event',
       all_day: false,
+    },
+    {
+      id: 'ev1',
+      start_utc: '2025-01-01T00:00:00Z',
+      end_utc: '2025-01-02T00:00:00Z',
+      title: 'All Day',
+      all_day: true,
     },
   ]);
 
   await pseudoLogin(page);
   await page.goto('/');
 
-  // All-day timeline should contain the mocked event
+  // Only the all-day event should appear on the timeline
   const timeline = page.locator('#all-day-timeline > li');
   await expect(timeline).toHaveCount(1);
 


### PR DESCRIPTION
## Summary
- add `filterAllDay` helper in `app.js`
- store all-day events and render only those on the timeline
- update E2E test to check filtering logic

## Testing
- `pytest -q` *(fails: freezegun missing)*
- `npm run test:e2e` *(fails: playwright not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686f4b323840832db1368d151cf53bcf