### PR TITLE
Implement all-day timeline reset

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -77,6 +77,14 @@ export function filterAllDay(events) {
   return (events || []).filter(ev => ev.all_day);
 }
 
+/**
+ * Remove all existing <li> elements from the all-day timeline.
+ */
+export function resetAllDayTimeline() {
+  const ul = document.getElementById('all-day-timeline');
+  if (ul) ul.innerHTML = '';
+}
+
 (async () => {
 
   /** Event[] を取得 */
@@ -88,6 +96,7 @@ export function filterAllDay(events) {
     const events = await fetchEvents(todayUtcISO());
     const allDay = filterAllDay(events);
     window.allDayEvents = allDay;
+    resetAllDayTimeline();
     window.renderAllDay(allDay);
   } catch (err) {
     console.error(err);
@@ -670,6 +679,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const events = await apiFetch(`/api/calendar?date=${ymd}`);
       const allDay = filterAllDay(events);
       window.allDayEvents = allDay;
+      resetAllDayTimeline();
       window.renderAllDay(allDay);
     } catch (err) {
       console.error('[calendar] reload failed', err);
@@ -692,6 +702,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const events = await apiFetch(`/api/calendar?date=${ymd}`);
       const allDay = filterAllDay(events);
       window.allDayEvents = allDay;
+      resetAllDayTimeline();
       window.renderAllDay(allDay);
     } catch (err) {
       console.error(err);

--- a/tests/e2e/schedule.spec.ts
+++ b/tests/e2e/schedule.spec.ts
@@ -39,10 +39,10 @@ test('page shows logged-in state after pseudo login and reload', async ({ page }
 test('all-day timeline clears on date change', async ({ page }) => {
   await pseudoLogin(page);
 
+  let call = 0;
   await page.route('**/api/calendar**', route => {
-    const url = new URL(route.request().url());
-    const date = url.searchParams.get('date');
-    const events = date?.startsWith('2025-01-01')
+    call++;
+    const events = call === 1
       ? [{
           id: 'evA',
           start_utc: '2025-01-01T00:00:00Z',

--- a/tests/e2e/schedule.spec.ts
+++ b/tests/e2e/schedule.spec.ts
@@ -35,3 +35,68 @@ test('page shows logged-in state after pseudo login and reload', async ({ page }
   await page.reload();
   await expect(timeline).toHaveCount(1);
 });
+
+test('all-day timeline clears on date change', async ({ page }) => {
+  await pseudoLogin(page);
+
+  await page.route('**/api/calendar**', route => {
+    const url = new URL(route.request().url());
+    const date = url.searchParams.get('date');
+    const events = date?.startsWith('2025-01-01')
+      ? [{
+          id: 'evA',
+          start_utc: '2025-01-01T00:00:00Z',
+          end_utc: '2025-01-02T00:00:00Z',
+          title: 'All Day A',
+          all_day: true,
+        }]
+      : [];
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(events) });
+  });
+
+  await page.goto('/');
+
+  const timeline = page.locator('#all-day-timeline > li');
+  await expect(timeline).toHaveCount(1);
+
+  await page.evaluate(() => {
+    const input = document.getElementById('input-date') as HTMLInputElement;
+    input.value = '2025-01-02';
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+
+  await expect(timeline).toHaveCount(0);
+});
+
+test('all-day timeline clears after generating schedule', async ({ page }) => {
+  await pseudoLogin(page);
+
+  let call = 0;
+  await page.route('**/api/calendar**', route => {
+    call++;
+    const events = call === 1
+      ? [{
+          id: 'evB',
+          start_utc: '2025-01-01T00:00:00Z',
+          end_utc: '2025-01-02T00:00:00Z',
+          title: 'All Day B',
+          all_day: true,
+        }]
+      : [];
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(events) });
+  });
+
+  await page.route('**/api/schedule/generate**', route => {
+    const body = JSON.stringify({ date: '2025-01-01', slots: new Array(144).fill(0), unplaced: [] });
+    route.fulfill({ status: 200, contentType: 'application/json', body });
+  });
+
+  await page.goto('/');
+
+  const timeline = page.locator('#all-day-timeline > li');
+  await expect(timeline).toHaveCount(1);
+
+  await page.getByTestId('generate-btn').click();
+
+  await expect(timeline).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- add `resetAllDayTimeline()` to clear existing chips
- call timeline reset before rendering all-day events
- test that timeline clears on date change and schedule generation

## Testing
- `npm test` *(fails: unable to install packages)*
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f4d3afed8832dbf642659466ffd33