### PR TITLE
Add all-day chip template

### DIFF
--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -66,16 +66,15 @@
   ></ul>
 
   <!-- クライアント側 JS から clone して使うテンプレート -->
-  <template id="tpl-all-day-chip">
-    <li role="listitem" class="inline">
-      <button
-        type="button"
-        class="chip-btn inline-flex items-center rounded-full
-               bg-blue-100 text-blue-800 text-xs font-medium
-               px-3 py-1 whitespace-nowrap
-               focus-visible:ring-2 focus-visible:ring-blue-400"
-      ></button>
-    </li>
+  <template id="all-day-chip">
+    <button
+      type="button"
+      aria-label=""
+      class="chip-btn inline-flex items-center rounded-full
+             bg-blue-100 text-blue-800 text-xs font-medium
+             px-3 py-1 whitespace-nowrap
+             focus-visible:ring-2 focus-visible:ring-blue-400"
+    ></button>
   </template>
 </section>
 <!-- ───── End All-day timeline ───── -->
@@ -173,19 +172,23 @@
     // ここでは JS が未実装でもテスト用に global stub を提供しておく。
     window.renderAllDay ??= (events) => {
       const ul   = document.getElementById('all-day-timeline');
-      const tmpl = document.getElementById('tpl-all-day-chip');
+      const tmpl = document.getElementById('all-day-chip');
       ul.innerHTML = '';
 
       events.forEach((ev) => {
-        const li  = tmpl.content.firstElementChild.cloneNode(true);
-        const btn = li.querySelector('.chip-btn');
+        const btn = tmpl.content.firstElementChild.cloneNode(true);
         btn.textContent = ev.title;
+        btn.setAttribute('aria-label', ev.title);
 
         // デモ用クリックハンドラ
         btn.addEventListener('click', () => {
           console.log('All\u2011day chip clicked:', ev.id);
         });
 
+        const li = document.createElement('li');
+        li.role = 'listitem';
+        li.className = 'inline';
+        li.appendChild(btn);
         ul.appendChild(li);
       });
     };


### PR DESCRIPTION
## Summary
- use `<template id="all-day-chip">` for all-day timeline chips
- update render stub to clone the new template and create `<li>` wrappers

## Testing
- `pytest -q` *(fails: freezegun missing)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f50cbf674832d98080e4fdd28c08b