### PR TITLE
Exclude all-day events from schedule generation

### DIFF
--- a/schedule_app/services/schedule.py
+++ b/schedule_app/services/schedule.py
@@ -47,9 +47,14 @@ def _mark_busy(slot_map: list[bool], start: datetime, end: datetime, *, base: da
 
 
 def _init_slot_map(start_utc: datetime, events: list[Event], blocks: list[Block]) -> list[bool]:
-    """Return a slot map initialised with busy periods for ``start_utc``."""
+    """Return a slot map initialised with busy periods for ``start_utc``.
+
+    All-day events are skipped because they do not occupy time slots.
+    """
     slot_map = [False] * DAY_SLOTS
     for ev in events:
+        if ev.all_day:
+            continue
         _mark_busy(slot_map, ev.start_utc, ev.end_utc, base=start_utc)
     for blk in blocks:
         _mark_busy(slot_map, blk.start_utc, blk.end_utc, base=start_utc)
@@ -122,6 +127,8 @@ def generate(
 def generate_schedule(target_day: date, *, algo: str = "greedy") -> dict:
     """Return a simple JSON friendly schedule for ``target_day``.
 
+    All-day events are ignored when generating the time grid.
+
     Parameters
     ----------
     target_day:
@@ -145,7 +152,7 @@ def generate_schedule(target_day: date, *, algo: str = "greedy") -> dict:
     events = [
         ev
         for ev in EVENTS.values()
-        if ev.end_utc > start_utc and ev.start_utc < end_utc
+        if ev.end_utc > start_utc and ev.start_utc < end_utc and not ev.all_day
     ]
 
     tasks = list(TASKS.values())

--- a/tests/unit/test_schedule.py
+++ b/tests/unit/test_schedule.py
@@ -105,3 +105,24 @@ def test_event_spans_midnight() -> None:
     assert slots[:3] == [1] * 3
     assert slots[3] == 0
 
+
+@freeze_time("2025-01-01T00:00:00Z")
+def test_all_day_event_ignored() -> None:
+    TASKS.clear()
+    BLOCKS.clear()
+    from schedule_app.api.calendar import EVENTS
+
+    EVENTS.clear()
+    EVENTS["ad"] = Event(
+        id="ad",
+        title="",
+        start_utc=_dt("2025-01-01T00:00:00Z"),
+        end_utc=_dt("2025-01-02T00:00:00Z"),
+        all_day=True,
+    )
+
+    result = schedule.generate_schedule(target_day=date(2025, 1, 1))
+    slots = result["slots"]
+    assert len(slots) == 144
+    assert all(s == 0 for s in slots)
+


### PR DESCRIPTION
## Summary
- ignore all-day events when generating busy slot maps
- add regression test for all-day events
- document skipping of all-day events

## Testing
- `ruff check schedule_app/services/schedule.py tests/unit/test_schedule.py`
- `pytest -q` *(fails: freezegun is required)*
- `npx playwright test` *(fails: cannot fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_686f681c1588832d92230d5d55465116