### PR TITLE
Update README on all-day events

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Google API.
 The front-end will automatically build the `#time-grid` element at page load if
 it is missing.
 
+終日イベントはページ上部にチップ形式で表示され、スケジュールには配置されません。
+
 
 ## Google Calendar Stub
 


### PR DESCRIPTION
## Summary
- add note about how all-day events display on the calendar

## Testing
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_686fab500e2c832d8aa350e369e33e02