### PR TITLE
Add schedule card color classes

### DIFF
--- a/schedule_app/static/css/styles.css
+++ b/schedule_app/static/css/styles.css
@@ -134,8 +134,34 @@
 
   /* 個々のチップボタン */
   #all-day-timeline .chip-btn {
-    @apply inline-flex items-center rounded-full bg-blue-100 text-blue-800
+    @apply inline-flex items-center rounded-full bg-blue-100 text-gray-800
            text-xs font-medium px-3 py-1 whitespace-nowrap;
+  }
+}
+
+/*
+  ----------------------------------------------------------
+  Color variants for schedule cards and blocks
+  ---------------------------------------------------------- */
+
+@layer components {
+  /* Regular event cards */
+  .event-card {
+    @apply bg-green-100 border border-green-400 text-gray-900;
+  }
+
+  /* Task cards by priority */
+  .task-priority-a {
+    @apply bg-orange-100 border border-orange-400 text-gray-900;
+  }
+
+  .task-priority-b {
+    @apply bg-yellow-100 border border-yellow-400 text-gray-900;
+  }
+
+  /* Blocked time range */
+  .block-slot {
+    @apply bg-red-100 border border-red-400 text-gray-900;
   }
 }
 


### PR DESCRIPTION
## Summary
- update all-day chip color to use gray text
- add Tailwind component classes for events, task priorities, and blocks

## Testing
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_686fb1f30a4c832d822ac66ba408d5c4