### PR TITLE
Add Google Sheets env defaults

### DIFF
--- a/schedule_app/config.py
+++ b/schedule_app/config.py
@@ -45,6 +45,11 @@ class _Config:
     TIMEZONE: str = os.getenv("TIMEZONE", "Asia/Tokyo")
     SLOT_SEC: int = int(os.getenv("SLOT_SEC", "600"))  # 10min
 
+    # --- Google Sheets ---
+    SHEETS_TASKS_SSID: str | None = os.getenv("SHEETS_TASKS_SSID")
+    SHEETS_TASKS_RANGE: str = os.getenv("SHEETS_TASKS_RANGE", "Tasks!A:F")
+    SHEETS_CACHE_SEC: int = int(os.getenv("SHEETS_CACHE_SEC", "300"))
+
     # 追加があった場合はここへ…
 
     # ---- パス系（自動計算） ----

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,17 @@
+import importlib
+
+import schedule_app.config as config_module
+
+
+def test_defaults(monkeypatch):
+    monkeypatch.delenv("SHEETS_TASKS_SSID", raising=False)
+    monkeypatch.delenv("SHEETS_TASKS_RANGE", raising=False)
+    monkeypatch.delenv("SHEETS_CACHE_SEC", raising=False)
+
+    # Reload module to apply env changes
+    importlib.reload(config_module)
+    cfg = config_module.cfg
+
+    assert cfg.SHEETS_TASKS_RANGE == "Tasks!A:F"
+    assert cfg.SHEETS_CACHE_SEC == 300
+    assert cfg.SHEETS_TASKS_SSID is None


### PR DESCRIPTION
## Summary
- load optional Google Sheets task settings from env vars
- test config defaults when variables are unset
- fix lint in test

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_68704dba18bc832dabb9b9bff42ef77d