### PR TITLE
Fix OAuth scopes

### DIFF
--- a/schedule_app/__init__.py
+++ b/schedule_app/__init__.py
@@ -57,7 +57,7 @@ def _build_flow(*, redirect_uri: str) -> Flow:
         "https://www.googleapis.com/auth/userinfo.profile",
         "https://www.googleapis.com/auth/userinfo.email",
         "https://www.googleapis.com/auth/calendar.readonly",
-        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/spreadsheets.readonly",
     ]
 
     return Flow.from_client_config(

--- a/tests/unit/test_oauth_scopes.py
+++ b/tests/unit/test_oauth_scopes.py
@@ -1,0 +1,21 @@
+import schedule_app
+
+
+def test_build_flow_scopes(monkeypatch):
+    captured = {}
+
+    def dummy_get_setting(name: str) -> str:
+        return "dummy"
+
+    def dummy_from_client_config(client_config, scopes, redirect_uri=None):
+        captured["scopes"] = scopes
+        class DummyFlow:
+            pass
+        return DummyFlow()
+
+    monkeypatch.setattr("schedule_app._get_setting", dummy_get_setting)
+    monkeypatch.setattr("schedule_app.Flow.from_client_config", dummy_from_client_config)
+
+    schedule_app._build_flow(redirect_uri="http://localhost")
+    assert "https://www.googleapis.com/auth/spreadsheets.readonly" in captured["scopes"]
+


### PR DESCRIPTION
## Summary
- use readonly spreadsheets scope in `_build_flow`
- unit test for OAuth scopes

## Testing
- `pytest -q` *(fails: freezegun required)*

------
https://chatgpt.com/codex/tasks/task_e_6870567c3a94832d9b46b2f0718236eb