### PR TITLE
Add spreadsheets scope to OAuth setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ the default IANA zone used when parsing API dates that lack timezone
 information. It defaults to `cfg.TIMEZONE` but may be changed to any valid zone
 identifier.
 
+## OAuth Setup
+
+Create Google OAuth 2.0 credentials and set `GOOGLE_CLIENT_ID`,
+`GOOGLE_CLIENT_SECRET` and `OAUTH_REDIRECT_URI` in your environment. The
+application requests the following scopes:
+
+```
+openid profile email
+https://www.googleapis.com/auth/calendar.readonly
+https://www.googleapis.com/auth/spreadsheets.readonly
+```
+
 ## Running Tests
 
 The test suite depends on the `freezegun` library to control time. Tests will


### PR DESCRIPTION
## Summary
- document OAuth credentials setup
- note new Google Sheets readonly scope

## Testing
- `pre-commit run --files README.md` *(fails: command not found)*
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_68705f4d8bb8832d903b75d25e6f474a