### PR TITLE
Fix redirect URI env var name

### DIFF
--- a/schedule_app/__init__.py
+++ b/schedule_app/__init__.py
@@ -109,7 +109,7 @@ def create_app(*, testing: bool = False) -> Flask:  # type: ignore[name-defined]
     def login():
         """Begin the OAuth2 PKCE flow and redirect the user."""
 
-        redirect_uri = _get_setting("GOOGLE_REDIRECT_URI")
+        redirect_uri = _get_setting("OAUTH_REDIRECT_URI")
         flow = _build_flow(redirect_uri=redirect_uri)
         auth_url, state = flow.authorization_url(
             include_granted_scopes="true",
@@ -130,7 +130,7 @@ def create_app(*, testing: bool = False) -> Flask:  # type: ignore[name-defined]
         if not code:
             abort(400)
 
-        redirect_uri = _get_setting("GOOGLE_REDIRECT_URI")
+        redirect_uri = _get_setting("OAUTH_REDIRECT_URI")
         flow = _build_flow(redirect_uri=redirect_uri)
         flow.code_verifier = session.get("pkce_verifier")
         flow.fetch_token(code=code)

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -19,7 +19,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 os.environ.setdefault("GOOGLE_CLIENT_ID", "dummy-client-id")
 os.environ.setdefault("GOOGLE_CLIENT_SECRET", "dummy-secret")
-os.environ.setdefault("GOOGLE_REDIRECT_URI", "http://localhost:5173/callback")
+os.environ.setdefault("OAUTH_REDIRECT_URI", "http://localhost:5173/callback")
 
 # ---------------------------------------------------------------------------
 # Fixtures


### PR DESCRIPTION
## Summary
- rename `GOOGLE_REDIRECT_URI` to `OAUTH_REDIRECT_URI`
- update integration tests for the new variable

## Testing
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_6870637e95ac832db45452d7bc83baa5