### PR TITLE
Fix serialization of earliest_start_utc to exclude microseconds

### DIFF
--- a/schedule_app/api/tasks.py
+++ b/schedule_app/api/tasks.py
@@ -92,7 +92,9 @@ def _serialize(task: Task) -> dict[str, Any]:
     d = asdict(task)
     if d["earliest_start_utc"] is not None:
         d["earliest_start_utc"] = (
-            d["earliest_start_utc"].astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+            d["earliest_start_utc"].astimezone(timezone.utc)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "Z")
         )
     return d
 

--- a/tests/integration/test_tasks.py
+++ b/tests/integration/test_tasks.py
@@ -53,6 +53,21 @@ def test_create_and_get(client) -> None:
     assert len(resp.get_json()) == 1
 
 
+def test_microsecond_truncation(client) -> None:
+    payload = {
+        "title": "Task",
+        "category": "general",
+        "duration_min": 20,
+        "duration_raw_min": 25,
+        "priority": "A",
+        "earliest_start_utc": "2025-01-01T09:00:00.123456Z",
+    }
+    resp = client.post("/api/tasks", json=payload)
+    assert resp.status_code == 201
+    data = resp.get_json()
+    assert data["earliest_start_utc"] == "2025-01-01T09:00:00Z"
+
+
 def test_validation_error(client) -> None:
     payload = {
         "title": "bad",


### PR DESCRIPTION
## Summary
- ensure earliest_start_utc in tasks API always omits microseconds
- cover this behaviour with integration test

## Testing
- `pytest -q` *(fails: freezegun is required to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_6870659d3f38832d8437e7477518c6d5