### PR TITLE
Add Google Sheets API scope

### DIFF
--- a/schedule_app/services/google_client.py
+++ b/schedule_app/services/google_client.py
@@ -34,12 +34,17 @@ class GoogleAPIUnauthorized(APIError):
 
 # OAuth scopes required for accessing Google APIs
 
+# Scope for read-only access to Google Sheets
+SPREADSHEETS_READONLY_SCOPE = (
+    "https://www.googleapis.com/auth/spreadsheets.readonly"
+)
+
 SCOPES = [
     "openid",
     "profile",
     "email",
     "https://www.googleapis.com/auth/calendar.readonly",
-    "https://www.googleapis.com/auth/spreadsheets.readonly",
+    SPREADSHEETS_READONLY_SCOPE,
 ]
 
 


### PR DESCRIPTION
## Summary
- add a constant for the read-only Google Sheets scope
- include it in the list of OAuth scopes

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_687067bc1c20832da074ac46e5839e59