### PR TITLE
Add Google Sheets tasks service

### DIFF
--- a/schedule_app/services/sheets_tasks.py
+++ b/schedule_app/services/sheets_tasks.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+import time
+
+from google.oauth2.credentials import Credentials  # type: ignore
+from googleapiclient.discovery import build  # type: ignore
+
+from schedule_app.config import cfg
+from schedule_app.models import Task
+
+
+# Simple in-memory cache (tasks, expiry timestamp)
+_CACHE: tuple[list[Task], float] | None = None
+
+
+def _parse_dt(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _to_task(data: dict[str, str]) -> Task:
+    duration_min = int(data.get("duration_min", "0"))
+    duration_raw_min = int(data.get("duration_raw_min", str(duration_min)))
+    return Task(
+        id=data.get("id", ""),
+        title=data.get("title", ""),
+        category=data.get("category", ""),
+        duration_min=duration_min,
+        duration_raw_min=duration_raw_min,
+        priority=data.get("priority", "B"),
+        earliest_start_utc=_parse_dt(data.get("earliest_start_utc")),
+    )
+
+
+def fetch_tasks_from_sheet(session: dict[str, Any], *, force: bool = False) -> list[Task]:
+    """Return tasks fetched from Google Sheets."""
+
+    global _CACHE
+
+    now = time.time()
+    if _CACHE is not None and not force:
+        tasks, expiry = _CACHE
+        if now < expiry:
+            return tasks
+
+    ssid = cfg.SHEETS_TASKS_SSID
+    if not ssid:
+        return []
+
+    creds_info = session.get("credentials")
+    if not creds_info:
+        raise RuntimeError("missing credentials")
+
+    creds = Credentials(token=creds_info.get("access_token"))
+    service = build("sheets", "v4", credentials=creds, cache_discovery=False)
+    resp = (
+        service.spreadsheets()
+        .values()
+        .get(spreadsheetId=ssid, range=cfg.SHEETS_TASKS_RANGE)
+        .execute()
+    )
+
+    rows = resp.get("values", [])
+    tasks: list[Task] = []
+    if rows:
+        headers = [str(h).strip().lower() for h in rows[0]]
+        for row in rows[1:]:
+            data = {headers[i]: row[i] for i in range(min(len(headers), len(row)))}
+            tasks.append(_to_task(data))
+
+    _CACHE = (tasks, now + cfg.SHEETS_CACHE_SEC)
+    return tasks
+
+
+__all__ = ["fetch_tasks_from_sheet"]

--- a/tests/unit/test_sheets_tasks.py
+++ b/tests/unit/test_sheets_tasks.py
@@ -7,8 +7,8 @@ import schedule_app.config as config_module
 
 
 class DummyService:
-    def __init__(self, values):
-        self.values = values
+    def __init__(self, rows):
+        self.rows = rows
         self.calls = 0
 
     def spreadsheets(self):
@@ -24,7 +24,7 @@ class DummyService:
         return self
 
     def execute(self):
-        return {"values": self.values}
+        return {"values": self.rows}
 
 
 def _setup(monkeypatch, values, cache_sec=60):

--- a/tests/unit/test_sheets_tasks.py
+++ b/tests/unit/test_sheets_tasks.py
@@ -1,0 +1,111 @@
+import importlib
+from datetime import datetime, timezone, timedelta
+
+from freezegun import freeze_time
+
+import schedule_app.config as config_module
+
+
+class DummyService:
+    def __init__(self, values):
+        self.values = values
+        self.calls = 0
+
+    def spreadsheets(self):
+        return self
+
+    def values(self):
+        return self
+
+    def get(self, spreadsheetId, range):  # noqa: D401 - simple stub
+        self.calls += 1
+        self.spreadsheetId = spreadsheetId
+        self.range = range
+        return self
+
+    def execute(self):
+        return {"values": self.values}
+
+
+def _setup(monkeypatch, values, cache_sec=60):
+    monkeypatch.setenv("SHEETS_TASKS_SSID", "sheet-id")
+    monkeypatch.setenv("SHEETS_TASKS_RANGE", "Tasks!A:G")
+    monkeypatch.setenv("SHEETS_CACHE_SEC", str(cache_sec))
+    importlib.reload(config_module)
+    import schedule_app.services.sheets_tasks as st
+    importlib.reload(st)
+    service = DummyService(values)
+    monkeypatch.setattr(st, "build", lambda *a, **k: service)
+    st._CACHE = None
+    return st, service
+
+
+def test_fetch_tasks_basic(monkeypatch):
+    rows = [
+        [
+            "id",
+            "title",
+            "category",
+            "duration_min",
+            "duration_raw_min",
+            "priority",
+            "earliest_start_utc",
+        ],
+        [
+            "t1",
+            "Task1",
+            "gen",
+            "20",
+            "25",
+            "A",
+            "2025-01-01T09:00:00Z",
+        ],
+        ["t2", "Task2", "gen", "10", "10", "B", ""],
+    ]
+
+    st, service = _setup(monkeypatch, rows)
+    session = {"credentials": {"access_token": "tok"}}
+    tasks = st.fetch_tasks_from_sheet(session, force=True)
+
+    assert service.calls == 1
+    assert len(tasks) == 2
+    t1 = tasks[0]
+    assert t1.id == "t1"
+    assert t1.duration_min == 20
+    assert t1.duration_raw_min == 25
+    assert t1.priority == "A"
+    assert t1.earliest_start_utc == datetime(2025, 1, 1, 9, 0, tzinfo=timezone.utc)
+    assert tasks[1].earliest_start_utc is None
+
+
+def test_fetch_tasks_cache(monkeypatch):
+    rows1 = [
+        [
+            "id",
+            "title",
+            "category",
+            "duration_min",
+            "duration_raw_min",
+            "priority",
+        ],
+        ["a", "A", "c", "10", "10", "A"],
+    ]
+
+    with freeze_time("2025-01-01T00:00:00Z") as frozen:
+        st, service1 = _setup(monkeypatch, rows1, cache_sec=10)
+        session = {"credentials": {"access_token": "tok"}}
+        tasks1 = st.fetch_tasks_from_sheet(session, force=True)
+        assert service1.calls == 1
+
+        rows2 = [["id", "title", "category", "duration_min", "duration_raw_min", "priority"], ["b", "B", "c", "5", "5", "B"]]
+        service2 = DummyService(rows2)
+        monkeypatch.setattr(st, "build", lambda *a, **k: service2)
+
+        tasks2 = st.fetch_tasks_from_sheet(session)
+        assert service2.calls == 0
+        assert tasks2 == tasks1
+
+        frozen.tick(delta=timedelta(seconds=11))
+        tasks3 = st.fetch_tasks_from_sheet(session)
+        assert service2.calls == 1
+        assert tasks3 != tasks1


### PR DESCRIPTION
## Summary
- implement `fetch_tasks_from_sheet` to read tasks from Google Sheets using Google API client
- cache fetched tasks using TTL from `SHEETS_CACHE_SEC`
- add unit tests covering parsing and cache behaviour

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_687069508de0832d996d82afc5b2bc2b