### PR TITLE
Validate sheet task durations

### DIFF
--- a/schedule_app/services/sheets_tasks.py
+++ b/schedule_app/services/sheets_tasks.py
@@ -37,6 +37,19 @@ def _parse_dt(value: str | None) -> datetime | None:
     return dt.astimezone(timezone.utc)
 
 
+def _validate_durations(duration_min: int, duration_raw_min: int) -> None:
+    ok = (
+        isinstance(duration_min, int)
+        and isinstance(duration_raw_min, int)
+        and duration_min > 0
+        and duration_raw_min > 0
+        and duration_min % 5 == 0
+        and duration_raw_min % 5 == 0
+    )
+    if not ok:
+        raise InvalidSheetRowError("invalid duration")
+
+
 def _to_task(data: dict[str, str]) -> Task:
     """Return a :class:`Task` converted from a sheet row dictionary."""
 
@@ -49,6 +62,8 @@ def _to_task(data: dict[str, str]) -> Task:
         raw_raw_min = int(data.get("duration_raw_min", str(raw_min)))
     except ValueError as e:  # pragma: no cover - invalid sheet data
         raise InvalidSheetRowError("invalid duration") from e
+
+    _validate_durations(raw_min, raw_raw_min)
 
     duration_min = math.ceil(raw_min / 10) * 10 if raw_min > 0 else 0
 

--- a/tests/unit/test_sheets_tasks.py
+++ b/tests/unit/test_sheets_tasks.py
@@ -140,3 +140,10 @@ def test_to_task_invalid_datetime(monkeypatch):
     st, _ = _setup(monkeypatch, [])
     with pytest.raises(st.InvalidSheetRowError):
         st._to_task({"priority": "A", "duration_min": "10", "duration_raw_min": "10", "earliest_start_utc": "bad"})
+
+
+@pytest.mark.parametrize("val", ["9", "-5"])
+def test_to_task_invalid_duration(monkeypatch, val):
+    st, _ = _setup(monkeypatch, [])
+    with pytest.raises(st.InvalidSheetRowError):
+        st._to_task({"priority": "A", "duration_min": val, "duration_raw_min": val})

--- a/tests/unit/test_sheets_tasks.py
+++ b/tests/unit/test_sheets_tasks.py
@@ -119,15 +119,15 @@ def test_to_task_uuid_and_round(monkeypatch):
         "id": "",
         "title": "T",
         "category": "c",
-        "duration_min": "21",
-        "duration_raw_min": "21",
+        "duration_min": "25",
+        "duration_raw_min": "25",
         "priority": "A",
     }
 
     task = st._to_task(data)
     assert task.id
     assert task.duration_min == 30
-    assert task.duration_raw_min == 21
+    assert task.duration_raw_min == 25
 
 
 def test_to_task_priority_error(monkeypatch):


### PR DESCRIPTION
## Summary
- validate duration inputs from Sheets
- ensure parsing rejects invalid durations
- test invalid durations in Sheets parser

## Testing
- `pre-commit run --files schedule_app/services/sheets_tasks.py tests/unit/test_sheets_tasks.py`
- `pytest -q tests/unit/test_sheets_tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_68706fce229c832dbd3f076e03dcb88a