### PR TITLE
Add unit test for invalid sheet task duration

### DIFF
--- a/tests/unit/test_sheets_tasks.py
+++ b/tests/unit/test_sheets_tasks.py
@@ -147,3 +147,9 @@ def test_to_task_invalid_duration(monkeypatch, val):
     st, _ = _setup(monkeypatch, [])
     with pytest.raises(st.InvalidSheetRowError):
         st._to_task({"priority": "A", "duration_min": val, "duration_raw_min": val})
+
+
+def test_to_task_non_numeric_duration(monkeypatch):
+    st, _ = _setup(monkeypatch, [])
+    with pytest.raises(st.InvalidSheetRowError):
+        st._to_task({"priority": "A", "duration_min": "abc", "duration_raw_min": "abc"})


### PR DESCRIPTION
## Summary
- cover non-numeric duration case in sheets tasks conversion

## Testing
- `ruff check tests/unit/test_sheets_tasks.py`
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_68707381b1a8832d967715b21dea322d