### PR TITLE
Add test for naive datetime

### DIFF
--- a/tests/unit/test_sheets_tasks.py
+++ b/tests/unit/test_sheets_tasks.py
@@ -153,3 +153,17 @@ def test_to_task_non_numeric_duration(monkeypatch):
     st, _ = _setup(monkeypatch, [])
     with pytest.raises(st.InvalidSheetRowError):
         st._to_task({"priority": "A", "duration_min": "abc", "duration_raw_min": "abc"})
+
+
+def test_to_task_naive_datetime(monkeypatch):
+    st, _ = _setup(monkeypatch, [])
+
+    data = {
+        "priority": "A",
+        "duration_min": "10",
+        "duration_raw_min": "10",
+        "earliest_start_utc": "2025-01-01T09:00:00",
+    }
+
+    task = st._to_task(data)
+    assert task.earliest_start_utc == datetime(2025, 1, 1, 9, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- verify `_to_task` handles naive datetime strings

## Testing
- `pytest tests/unit/test_sheets_tasks.py::test_to_task_naive_datetime -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_687074a43f1c832d94a8a0b5ffbc3cac