### PR TITLE
Handle whitespace around earliest_start_utc

### DIFF
--- a/schedule_app/services/sheets_tasks.py
+++ b/schedule_app/services/sheets_tasks.py
@@ -49,7 +49,7 @@ def _to_task(data: dict[str, str]) -> Task:
     if priority not in {"A", "B"}:
         raise InvalidSheetRowError("invalid priority")
 
-    earliest = data.get("earliest_start_utc")
+    earliest = (data.get("earliest_start_utc", "") or "").strip()
     try:
         es_dt = _parse_dt(earliest)
     except ValueError as e:

--- a/tests/unit/test_sheets_tasks.py
+++ b/tests/unit/test_sheets_tasks.py
@@ -167,3 +167,17 @@ def test_to_task_naive_datetime(monkeypatch):
 
     task = st._to_task(data)
     assert task.earliest_start_utc == datetime(2025, 1, 1, 9, 0, tzinfo=timezone.utc)
+
+
+def test_to_task_datetime_whitespace(monkeypatch):
+    st, _ = _setup(monkeypatch, [])
+
+    data = {
+        "priority": "A",
+        "duration_min": "10",
+        "duration_raw_min": "10",
+        "earliest_start_utc": " 2025-01-01T09:00:00Z ",
+    }
+
+    task = st._to_task(data)
+    assert task.earliest_start_utc == datetime(2025, 1, 1, 9, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- trim whitespace when parsing earliest_start_utc
- test that surrounding whitespace does not raise errors

## Testing
- `pytest -q` *(fails: Skipped: freezegun is required to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_687079a7c800832dbfe1c933f6ad95dd