### PR TITLE
Fix rounding logic in sheets tasks

### DIFF
--- a/schedule_app/services/sheets_tasks.py
+++ b/schedule_app/services/sheets_tasks.py
@@ -43,7 +43,7 @@ def _to_task(data: dict[str, str]) -> Task:
     except ValueError as e:
         raise InvalidSheetRowError("invalid duration") from e
 
-    duration_min = math.ceil(raw_min / 10) * 10 if raw_min > 0 else 0
+    duration_min = math.ceil(raw_min / 10) * 10
 
     priority = data.get("priority", "B").strip().upper() or "B"
     if priority not in {"A", "B"}:


### PR DESCRIPTION
## Summary
- always round durations up to the nearest 10 minutes

## Testing
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_68707a9a5640832da70bed4c525cc0fb