### PR TITLE
Add POST /api/tasks/import endpoint

### DIFF
--- a/schedule_app/api/tasks.py
+++ b/schedule_app/api/tasks.py
@@ -153,3 +153,20 @@ def import_tasks():
         raise APIError(str(exc))
 
     return jsonify([_serialize(t) for t in tasks])
+
+
+@bp.post("/import")
+def import_tasks_post():
+    """Fetch tasks from Google Sheets and replace existing tasks."""
+    try:
+        tasks = fetch_tasks_from_sheet(session, force=True)
+    except (InvalidSheetRowError, RuntimeError) as exc:
+        _problem(422, "invalid-field", str(exc))
+    except Exception as exc:  # pragma: no cover - network errors
+        raise APIError(str(exc))
+
+    TASKS.clear()
+    for t in tasks:
+        TASKS[t.id] = t
+
+    return ("", 204)

--- a/tests/integration/test_tasks.py
+++ b/tests/integration/test_tasks.py
@@ -190,3 +190,79 @@ def test_import_tasks_api_error(client) -> None:
     assert resp.status_code == 502
     _assert_problem_details(resp.get_json())
 
+
+def _create_sample_task(client) -> str:
+    payload = {
+        "title": "Old",
+        "category": "c",
+        "duration_min": 10,
+        "duration_raw_min": 10,
+        "priority": "A",
+    }
+    resp = client.post("/api/tasks", json=payload)
+    return resp.get_json()["id"]
+
+
+def test_import_tasks_post_replace(client) -> None:
+    old_id = _create_sample_task(client)
+
+    new_tasks = [
+        Task(
+            id="n1",
+            title="New",
+            category="c",
+            duration_min=20,
+            duration_raw_min=20,
+            priority="A",
+        )
+    ]
+
+    with patch(
+        "schedule_app.api.tasks.fetch_tasks_from_sheet",
+        return_value=new_tasks,
+    ):
+        resp = client.post("/api/tasks/import")
+
+    assert resp.status_code == 204
+
+    resp = client.get("/api/tasks")
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]["id"] == "n1"
+
+
+def test_import_tasks_post_validation_error(client) -> None:
+    old_id = _create_sample_task(client)
+
+    with patch(
+        "schedule_app.api.tasks.fetch_tasks_from_sheet",
+        side_effect=InvalidSheetRowError("bad"),
+    ):
+        resp = client.post("/api/tasks/import")
+
+    assert resp.status_code == 422
+    _assert_problem_details(resp.get_json())
+
+    resp = client.get("/api/tasks")
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]["id"] == old_id
+
+
+def test_import_tasks_post_api_error(client) -> None:
+    old_id = _create_sample_task(client)
+
+    with patch(
+        "schedule_app.api.tasks.fetch_tasks_from_sheet",
+        side_effect=Exception("boom"),
+    ):
+        resp = client.post("/api/tasks/import")
+
+    assert resp.status_code == 502
+    _assert_problem_details(resp.get_json())
+
+    resp = client.get("/api/tasks")
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]["id"] == old_id
+

--- a/tests/integration/test_tasks.py
+++ b/tests/integration/test_tasks.py
@@ -229,6 +229,7 @@ def test_import_tasks_post_replace(client) -> None:
     data = resp.get_json()
     assert len(data) == 1
     assert data[0]["id"] == "n1"
+    assert data[0]["id"] != old_id
 
 
 def test_import_tasks_post_validation_error(client) -> None:


### PR DESCRIPTION
## Summary
- add a new POST /api/tasks/import endpoint that replaces all tasks
- ensure errors from Sheets are handled consistently
- test importing tasks via POST in integration tests

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_68707eb93650832d92482c7f04d4281d