### PR TITLE
Add Sheets import button

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -240,6 +240,21 @@ document.addEventListener('DOMContentLoaded', () => {
   loadAndRenderTasks();
 });
 
+// Sheets Import button handler
+document.addEventListener('DOMContentLoaded', () => {
+  const btnImport = document.getElementById('btn-import-sheets');
+  if (!btnImport) return;
+  btnImport.addEventListener('click', async () => {
+    try {
+      await apiFetch('/api/tasks/import', { method: 'POST' });
+      await loadAndRenderTasks();
+    } catch (err) {
+      console.error('tasks import failed', err);
+      alert(err.message ?? err);
+    }
+  });
+});
+
 // Ensure a time grid exists for tests or pages missing it
 document.addEventListener('DOMContentLoaded', () => {
   if (document.querySelector('#time-grid')) return;

--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -52,6 +52,10 @@
             class="ml-auto border rounded px-3 py-1 text-sm bg-green-600 text-white hover:bg-green-700 active:translate-y-0.5">
       ＋タスク追加
     </button>
+    <button id="btn-import-sheets" type="button"
+            class="ml-2 border rounded px-3 py-1 text-sm bg-purple-600 text-white hover:bg-purple-700 active:translate-y-0.5">
+      Import from Sheets
+    </button>
   </header>
 <!-- ─────────── All-day timeline ─────────── -->
 <section

--- a/tests/e2e/print_visibility.spec.ts
+++ b/tests/e2e/print_visibility.spec.ts
@@ -7,7 +7,7 @@ test('header and toolbar buttons hidden when printing', async ({ page }) => {
   await expect(header).toBeVisible();
 
   const buttons = header.locator('button');
-  await expect(buttons).toHaveCount(4);
+  await expect(buttons).toHaveCount(5);
   for (let i = 0; i < await buttons.count(); i++) {
     await expect(buttons.nth(i)).toBeVisible();
   }


### PR DESCRIPTION
## Summary
- add a new **Import from Sheets** button on the main page
- call POST `/api/tasks/import` when pressed and reload tasks list

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_68708d4382bc832d91cb6fb9a987f2dc