### PR TITLE
Task 8: toast on Sheets import error

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -250,7 +250,10 @@ document.addEventListener('DOMContentLoaded', () => {
       await loadAndRenderTasks();
     } catch (err) {
       console.error('tasks import failed', err);
-      alert(err.message ?? err);
+      if (err && err.message === 'Unauthorized') {
+        return; // Redirect handled by apiFetch
+      }
+      showToast(err.message ?? err);
     }
   });
 });

--- a/tests/e2e/sheets_import.spec.ts
+++ b/tests/e2e/sheets_import.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+
+// Display toast when Sheets import fails
+
+test('sheets import error shows toast', async ({ page }) => {
+  await page.route('**/api/calendar**', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route('**/api/tasks/import', route =>
+    route.fulfill({
+      status: 422,
+      contentType: 'application/json',
+      body: JSON.stringify({ detail: 'sheet error' })
+    })
+  );
+
+  await page.goto('/');
+  await page.locator('#btn-import-sheets').click();
+
+  const toast = page.locator('.schedule-toast');
+  await expect(toast).toHaveCount(1);
+  await expect(toast).toBeVisible();
+  await expect(toast).toContainText('sheet error');
+});
+
+// Redirect to login on 401 response
+
+test('sheets import 401 redirects to login', async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'webdriver', { get: () => false });
+  });
+
+  await page.route('**/login', route =>
+    route.fulfill({ status: 200, contentType: 'text/html', body: 'login page' })
+  );
+  await page.route('**/api/calendar**', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route('**/api/tasks/import', route =>
+    route.fulfill({
+      status: 401,
+      contentType: 'application/json',
+      body: JSON.stringify({ detail: 'missing credentials' })
+    })
+  );
+
+  await page.goto('/');
+
+  await Promise.all([
+    page.waitForURL('**/login'),
+    page.locator('#btn-import-sheets').click(),
+  ]);
+
+  await expect(page).toHaveURL(/\/login$/);
+});


### PR DESCRIPTION
## Summary
- display toast on Sheets import errors
- redirect is handled by `apiFetch`
- add E2E tests for Sheets import error handling and 401 redirect

## Testing
- `npm run test:e2e` *(fails: playwright not found)*
- `pytest` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_68708ff71cdc832da2cf43a87c940474