### PR TITLE
Add 502 import error e2e test

### DIFF
--- a/tests/e2e/sheets_import.spec.ts
+++ b/tests/e2e/sheets_import.spec.ts
@@ -68,7 +68,13 @@ test('sheets import 502 shows error toast', async ({ page }) => {
   );
 
   await page.goto('/');
-  await page.locator('#btn-import-sheets').click();
+
+  await Promise.all([
+    page.waitForResponse(
+      r => r.url().includes('/api/tasks/import') && r.status() === 502
+    ),
+    page.locator('#btn-import-sheets').click(),
+  ]);
 
   const toast = page.locator('.schedule-toast');
   await expect(toast).toHaveCount(1);


### PR DESCRIPTION
## Summary
- add end-to-end test verifying toast when import fails with HTTP 502

## Testing
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870927941e8832d83dad5b0bf60e42b