### PR TITLE
Add 502 import error e2e test

### DIFF
--- a/tests/e2e/sheets_import.spec.ts
+++ b/tests/e2e/sheets_import.spec.ts
@@ -53,3 +53,31 @@ test('sheets import 401 redirects to login', async ({ page }) => {
 
   await expect(page).toHaveURL(/\/login$/);
 });
+
+// Display toast on server error
+test('sheets import 502 shows error toast', async ({ page }) => {
+  await page.route('**/api/calendar**', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route('**/api/tasks/import', route =>
+    route.fulfill({
+      status: 502,
+      contentType: 'application/json',
+      body: JSON.stringify({ detail: 'server down' })
+    })
+  );
+
+  await page.goto('/');
+
+  await Promise.all([
+    page.waitForResponse(
+      r => r.url().includes('/api/tasks/import') && r.status() === 502
+    ),
+    page.locator('#btn-import-sheets').click(),
+  ]);
+
+  const toast = page.locator('.schedule-toast');
+  await expect(toast).toHaveCount(1);
+  await expect(toast).toBeVisible();
+  await expect(toast).toContainText('server down');
+});


### PR DESCRIPTION
## Summary
- add end-to-end test verifying toast when import fails with HTTP 502

## Testing
- `npx playwright test tests/e2e/sheets_import.spec.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870927941e8832d83dad5b0bf60e42b