### PR TITLE
Handle tasks load errors

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -232,6 +232,7 @@ async function loadAndRenderTasks() {
     applyContrastClasses();
   } catch (err) {
     console.error('[tasks] failed to load', err);
+    showToast(err.message ?? err);
   }
 }
 

--- a/tests/e2e/tasks_fetch_error.spec.ts
+++ b/tests/e2e/tasks_fetch_error.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+import { mockGoogleCalendar } from './helpers';
+
+test('tasks API error shows toast', async ({ page }) => {
+  // Prevent calendar fetch from redirecting
+  await mockGoogleCalendar(page);
+
+  // Fail the tasks API request
+  await page.route('**/api/tasks', route =>
+    route.fulfill({
+      status: 502,
+      contentType: 'application/json',
+      body: JSON.stringify({ detail: 'server error' })
+    })
+  );
+
+  await page.goto('/');
+
+  const toast = page.locator('.schedule-toast');
+  await expect(toast).toHaveCount(1);
+  await expect(toast).toBeVisible();
+  await expect(toast).toContainText('server error');
+});

--- a/tests/e2e/unplaced.spec.ts
+++ b/tests/e2e/unplaced.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect } from '@playwright/test';
 
 test('unplaced task shows red highlight & toast', async ({ page, request }) => {
+  // Remove any existing tasks to avoid interference
+  const existing = await request.get('/api/tasks');
+  for (const t of await existing.json()) {
+    await request.delete(`/api/tasks/${t.id}`);
+  }
   /* ------- 1. 24 h を越えるタスクを 2 件投入して容量オーバーにする ------- */
   for (const i of [1, 2]) {
     await request.post('/api/tasks', {


### PR DESCRIPTION
## Summary
- show toast when tasks fail to load
- add e2e test verifying toast appears on `/api/tasks` error

## Testing
- `pytest -q` *(fails: freezegun missing)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68709465bdb4832da08ce1582b1aa08a