### PR TITLE
docs: document tasks cache endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Simple in-memory endpoints used by the front-end.
 | DELETE | `/api/tasks/<id>` | Remove a task |
 | GET | `/api/tasks/import` | Fetch tasks from Google Sheets |
 | POST | `/api/tasks/import` | Replace tasks with sheet data |
+| DELETE | `/api/tasks/cache` | Invalidate Google Sheets tasks cache |
 
 All datetimes are UTC RFC 3339 strings. Validation errors return a 422 response with type `https://schedule.app/errors/invalid-field`. The import endpoints may also return 422 for invalid sheet rows or 502 when Google Sheets cannot be reached.
 


### PR DESCRIPTION
## Summary
- document DELETE /api/tasks/cache endpoint in README

## Testing
- `pre-commit run --files README.md` *(fails: command not found)*
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_68709ba29b7c832da57f9cb335ef4c35