### PR TITLE
Fix default OAuth redirect path and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,16 @@ identifier.
 ## OAuth Setup
 
 Create Google OAuth 2.0 credentials and set `GOOGLE_CLIENT_ID`,
-`GOOGLE_CLIENT_SECRET` and `OAUTH_REDIRECT_URI` in your environment. The
-application requests the following scopes:
+`GOOGLE_CLIENT_SECRET` and `OAUTH_REDIRECT_URI` in your environment. For local
+development you can create a `.env` file containing:
+
+```env
+GOOGLE_CLIENT_ID=your-client-id
+GOOGLE_CLIENT_SECRET=your-secret
+OAUTH_REDIRECT_URI=http://localhost:5173/callback
+```
+
+The application requests the following scopes:
 
 ```
 openid profile email

--- a/schedule_app/config.py
+++ b/schedule_app/config.py
@@ -38,7 +38,7 @@ class _Config:
     GOOGLE_CLIENT_SECRET: str | None = os.getenv("GOOGLE_CLIENT_SECRET")  # PKCEでは不要
     OAUTH_REDIRECT_URI: str = os.getenv(
         "OAUTH_REDIRECT_URI",
-        "http://localhost:5173/oauth2callback",
+        "http://localhost:5173/callback",
     )
 
     # --- App Settings ---


### PR DESCRIPTION
## Summary
- update OAuth callback default value in `schedule_app/config.py`
- show how to set `OAUTH_REDIRECT_URI` in README

## Testing
- `pre-commit run --files schedule_app/config.py README.md` *(fails: command not found)*
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_68710211341c832d8c2bbf3f33c6e068