### PR TITLE
Use SECRET_KEY from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ https://www.googleapis.com/auth/calendar.readonly
 https://www.googleapis.com/auth/spreadsheets.readonly
 ```
 
+## Environment
+
+Set `SECRET_KEY` to any random string for Flask session security. A default
+`dev-secret-key` is used when the variable is unset, which is suitable for
+development only.
+
 ## Running Tests
 
 The test suite depends on the `freezegun` library to control time. Tests will

--- a/schedule_app/__init__.py
+++ b/schedule_app/__init__.py
@@ -72,7 +72,8 @@ def create_app(*, testing: bool = False) -> Flask:  # type: ignore[name-defined]
     from flask import jsonify, render_template, request
 
     app = Flask(__name__)
-    app.secret_key = "dev-secret-key"
+    # SECRET_KEY environment variable overrides the development key
+    app.secret_key = os.getenv("SECRET_KEY", "dev-secret-key")
 
     # Lightweight Google API client stub
     app.extensions["gclient"] = GoogleClient(credentials=None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ if str(ROOT) not in sys.path:
 # ---------------------------------------------------------------------------
 os.environ.setdefault("GCP_PROJECT", "dummy-project")
 os.environ.setdefault("GOOGLE_CLIENT_ID", "dummy-client-id")
+os.environ.setdefault("SECRET_KEY", "test-secret")
 
 if importlib.util.find_spec("freezegun") is None:
     pytest.skip("freezegun is required to run tests", allow_module_level=True)


### PR DESCRIPTION
## Summary
- read `SECRET_KEY` from the environment when creating the Flask app
- document the variable in the README
- set `SECRET_KEY` in the test environment

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_687105272b2c832daac43019f0376cbf