### PR TITLE
Update OAuth scopes

### DIFF
--- a/schedule_app/services/google_client.py
+++ b/schedule_app/services/google_client.py
@@ -42,8 +42,8 @@ SPREADSHEETS_READONLY_SCOPE = (
 
 SCOPES = [
     "openid",
-    "profile",
-    "email",
+    "https://www.googleapis.com/auth/userinfo.profile",
+    "https://www.googleapis.com/auth/userinfo.email",
     "https://www.googleapis.com/auth/calendar.readonly",
     SPREADSHEETS_READONLY_SCOPE,
 ]

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -66,6 +66,8 @@ def test_login_redirects_to_google(mock_flow_cls, client):
     called_scopes = mock_flow_cls.from_client_config.call_args.kwargs.get("scopes")
     assert called_scopes == SCOPES
     assert "https://www.googleapis.com/auth/spreadsheets.readonly" in called_scopes
+    assert "https://www.googleapis.com/auth/userinfo.profile" in called_scopes
+    assert "https://www.googleapis.com/auth/userinfo.email" in called_scopes
 
     loc = resp.headers["Location"]
     assert "accounts.google.com" in loc

--- a/tests/unit/test_oauth_scopes.py
+++ b/tests/unit/test_oauth_scopes.py
@@ -18,4 +18,6 @@ def test_build_flow_scopes(monkeypatch):
 
     schedule_app._build_flow(redirect_uri="http://localhost")
     assert "https://www.googleapis.com/auth/spreadsheets.readonly" in captured["scopes"]
+    assert "https://www.googleapis.com/auth/userinfo.profile" in captured["scopes"]
+    assert "https://www.googleapis.com/auth/userinfo.email" in captured["scopes"]
 


### PR DESCRIPTION
## Summary
- use canonical Google OAuth URLs for profile and email scopes
- verify new scopes in tests

## Testing
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_6871076153ec832d928f3f13de67aa69