### PR TITLE
Add title to Block dataclass

### DIFF
--- a/schedule_app/models.py
+++ b/schedule_app/models.py
@@ -29,6 +29,9 @@ class Task:
 
 @dataclass(slots=True, frozen=True)
 class Block:
+    """User-defined busy period with an optional label."""
+
     id: str
     start_utc: datetime
     end_utc: datetime
+    title: str | None = None


### PR DESCRIPTION
## Summary
- update `Block` dataclass to include optional `title`
- document the new field in a short class docstring

## Testing
- `pytest -q` *(fails: `freezegun` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68771622edcc832d8030af1afb36dc53