### PR TITLE
Add BLOCKS_SHEET_ID env setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ development you can create a `.env` file containing:
 GOOGLE_CLIENT_ID=your-client-id
 GOOGLE_CLIENT_SECRET=your-secret
 OAUTH_REDIRECT_URI=http://localhost:5173/callback
+BLOCKS_SHEET_ID=your-blocks-sheet-id
 ```
 
 The application requests the following scopes:

--- a/schedule_app/config.py
+++ b/schedule_app/config.py
@@ -49,6 +49,7 @@ class _Config:
     SHEETS_TASKS_SSID: str | None = os.getenv("SHEETS_TASKS_SSID")
     SHEETS_TASKS_RANGE: str = os.getenv("SHEETS_TASKS_RANGE", "Tasks!A:F")
     SHEETS_CACHE_SEC: int = int(os.getenv("SHEETS_CACHE_SEC", "300"))
+    BLOCKS_SHEET_ID: str | None = os.getenv("BLOCKS_SHEET_ID")
 
     # 追加があった場合はここへ…
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -7,6 +7,7 @@ def test_defaults(monkeypatch):
     monkeypatch.delenv("SHEETS_TASKS_SSID", raising=False)
     monkeypatch.delenv("SHEETS_TASKS_RANGE", raising=False)
     monkeypatch.delenv("SHEETS_CACHE_SEC", raising=False)
+    monkeypatch.delenv("BLOCKS_SHEET_ID", raising=False)
 
     # Reload module to apply env changes
     importlib.reload(config_module)
@@ -15,3 +16,4 @@ def test_defaults(monkeypatch):
     assert cfg.SHEETS_TASKS_RANGE == "Tasks!A:F"
     assert cfg.SHEETS_CACHE_SEC == 300
     assert cfg.SHEETS_TASKS_SSID is None
+    assert cfg.BLOCKS_SHEET_ID is None


### PR DESCRIPTION
## Summary
- support `BLOCKS_SHEET_ID` environment variable
- document in README
- update config tests

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_687717d04f60832d94f81450befa6e54