### PR TITLE
Add SHEETS_BLOCK_RANGE env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ GOOGLE_CLIENT_ID=your-client-id
 GOOGLE_CLIENT_SECRET=your-secret
 OAUTH_REDIRECT_URI=http://localhost:5173/callback
 BLOCKS_SHEET_ID=your-blocks-sheet-id
+SHEETS_BLOCK_RANGE=Blocks!A2:C
 ```
 
 The application requests the following scopes:

--- a/schedule_app/config.py
+++ b/schedule_app/config.py
@@ -50,6 +50,7 @@ class _Config:
     SHEETS_TASKS_RANGE: str = os.getenv("SHEETS_TASKS_RANGE", "Tasks!A:F")
     SHEETS_CACHE_SEC: int = int(os.getenv("SHEETS_CACHE_SEC", "300"))
     BLOCKS_SHEET_ID: str | None = os.getenv("BLOCKS_SHEET_ID")
+    SHEETS_BLOCK_RANGE: str = os.getenv("SHEETS_BLOCK_RANGE", "Blocks!A2:C")
 
     # 追加があった場合はここへ…
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -8,6 +8,7 @@ def test_defaults(monkeypatch):
     monkeypatch.delenv("SHEETS_TASKS_RANGE", raising=False)
     monkeypatch.delenv("SHEETS_CACHE_SEC", raising=False)
     monkeypatch.delenv("BLOCKS_SHEET_ID", raising=False)
+    monkeypatch.delenv("SHEETS_BLOCK_RANGE", raising=False)
 
     # Reload module to apply env changes
     importlib.reload(config_module)
@@ -17,3 +18,4 @@ def test_defaults(monkeypatch):
     assert cfg.SHEETS_CACHE_SEC == 300
     assert cfg.SHEETS_TASKS_SSID is None
     assert cfg.BLOCKS_SHEET_ID is None
+    assert cfg.SHEETS_BLOCK_RANGE == "Blocks!A2:C"


### PR DESCRIPTION
## Summary
- define `SHEETS_BLOCK_RANGE` in config with default `Blocks!A2:C`
- document new variable in README `.env` example
- ensure config unit test verifies default value

## Testing
- `pytest -q` *(fails: freezegun is missing)*

------
https://chatgpt.com/codex/tasks/task_e_687718eb182c832d901606d82a082d87