### PR TITLE
Add InvalidBlockRow error mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Simple in-memory endpoints used by the front-end.
 | DELETE | `/api/tasks/cache` | Invalidate Google Sheets tasks cache |
 
 All datetimes are UTC RFC 3339 strings. Validation errors return a 422 response with type `https://schedule.app/errors/invalid-field`. The import endpoints may also return 422 for invalid sheet rows or 502 when Google Sheets cannot be reached.
+Invalid block rows use the type `https://schedule.app/errors/invalid-block-row`.
 
 ## Schedule API
 

--- a/schedule_app/errors.py
+++ b/schedule_app/errors.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from werkzeug.exceptions import HTTPException
+
+
+class InvalidBlockRow(HTTPException):
+    """Raised when a block row contains invalid data."""
+
+    code = 422
+    description = "Block row validation failed"
+
+
+__all__ = ["InvalidBlockRow"]

--- a/tests/integration/test_problem_details.py
+++ b/tests/integration/test_problem_details.py
@@ -14,3 +14,27 @@ def test_invalid_field_422():
     assert body["title"] == "Validation failed"
     assert body["status"] == 422
     assert body["instance"] == "/api/tasks"
+
+
+def test_invalid_block_row():
+    app = create_app()
+
+    from flask import Blueprint
+    from schedule_app.errors import InvalidBlockRow
+
+    bp = Blueprint("testbp", __name__)
+
+    @bp.get("/raise-block")
+    def raise_block():  # pragma: no cover - simple test route
+        raise InvalidBlockRow()
+
+    app.register_blueprint(bp)
+    client = app.test_client()
+
+    res = client.get("/raise-block")
+
+    assert res.status_code == 422
+    body = res.get_json()
+    assert body["type"] == "https://schedule.app/errors/invalid-block-row"
+    assert body["title"] == "Block row validation failed"
+    assert body["status"] == 422


### PR DESCRIPTION
## Summary
- introduce `InvalidBlockRow` HTTPException in new module
- map the exception to `invalid-block-row` Problem Details type
- document the new error type
- test that the handler returns the proper problem response

## Testing
- `python -m py_compile schedule_app/errors.py schedule_app/__init__.py tests/integration/test_problem_details.py`
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_68771ac293a8832d95fa85753b5f8600