### PR TITLE
Add Google client blocks sheet test setup

### DIFF
--- a/tests/unit/test_google_client_blocks_sheet.py
+++ b/tests/unit/test_google_client_blocks_sheet.py
@@ -1,0 +1,40 @@
+import json
+
+
+class DummyResponse:
+    def __init__(self, data: dict) -> None:
+        self._data = json.dumps(data).encode()
+
+    def read(self) -> bytes:  # pragma: no cover - simple stub
+        return self._data
+
+    def __enter__(self) -> "DummyResponse":  # pragma: no cover - simple stub
+        return self
+
+    def __exit__(self, *exc):  # pragma: no cover - simple stub
+        return False
+
+
+def _setup(monkeypatch, rows):
+    import importlib
+    import schedule_app.config as config_module
+
+    monkeypatch.setenv("BLOCKS_SHEET_ID", "sheet-id")
+    monkeypatch.setenv("SHEETS_BLOCK_RANGE", "Blocks!A2:C")
+    monkeypatch.setenv("SHEETS_CACHE_SEC", "60")
+
+    importlib.reload(config_module)
+
+    import schedule_app.services.google_client as gc
+
+    gc.config_module = config_module
+    gc._BLOCK_CACHE = None
+    monkeypatch.setattr(gc.request, "urlopen", lambda req: DummyResponse({"values": rows}))
+
+    return gc
+
+
+def test_setup_reload(monkeypatch):
+    gc = _setup(monkeypatch, [])
+    assert gc.config_module.cfg.BLOCKS_SHEET_ID == "sheet-id"
+    assert gc._BLOCK_CACHE is None


### PR DESCRIPTION
## Summary
- add placeholder unit tests for Google Sheets blocks setup
- ensure config reloads and URL opener patched

## Testing
- `ruff check .`
- `pytest -n auto --dist loadscope` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_68772aacaa2c832db73967909d2eeca3