### PR TITLE
Implement blocks import from Google Sheets

### DIFF
--- a/schedule_app/services/google_client.py
+++ b/schedule_app/services/google_client.py
@@ -18,7 +18,7 @@ try:
 except Exception:  # pragma: no cover - missing env vars in some test runs
     config_module = None
 import json
-from datetime import datetime, time, timedelta, timezone
+from datetime import datetime, time as dt_time, timedelta, timezone
 import pytz
 
 from schedule_app.models import Event, Block
@@ -221,7 +221,7 @@ class GoogleClient:
 
         if date.tzinfo is None:
             # naïve → JST
-            local_start = tz.localize(datetime.combine(date.date(), time.min))
+            local_start = tz.localize(datetime.combine(date.date(), dt_time.min))
         else:
             # すでに aware なら JST に合わせる
             local_start = date.astimezone(tz).replace(

--- a/schedule_app/services/google_client.py
+++ b/schedule_app/services/google_client.py
@@ -21,9 +21,13 @@ import json
 from datetime import datetime, time, timedelta, timezone
 import pytz
 
-from schedule_app.models import Event
+from schedule_app.models import Event, Block
 from schedule_app.exceptions import APIError
 from schedule_app.utils.validation import _parse_dt
+from schedule_app.errors import InvalidBlockRow
+from schedule_app.services.rounding import quantize
+import uuid
+import time
 
 
 class GoogleAPIUnauthorized(APIError):
@@ -36,9 +40,7 @@ class GoogleAPIUnauthorized(APIError):
 # OAuth scopes required for accessing Google APIs
 
 # Scope for read-only access to Google Sheets
-SPREADSHEETS_READONLY_SCOPE = (
-    "https://www.googleapis.com/auth/spreadsheets.readonly"
-)
+SPREADSHEETS_READONLY_SCOPE = "https://www.googleapis.com/auth/spreadsheets.readonly"
 
 SCOPES = [
     "openid",
@@ -47,6 +49,80 @@ SCOPES = [
     "https://www.googleapis.com/auth/calendar.readonly",
     SPREADSHEETS_READONLY_SCOPE,
 ]
+
+# ---------------------------------------------------------------------------
+# Sheet helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_block(data: dict[str, str]) -> Block:
+    """Convert a sheet row ``data`` to a :class:`Block`."""
+
+    start_raw = (data.get("start_utc") or "").strip()
+    end_raw = (data.get("end_utc") or "").strip()
+    if not start_raw or not end_raw:
+        raise InvalidBlockRow()
+
+    try:
+        start_dt = _parse_dt(start_raw)
+        end_dt = _parse_dt(end_raw)
+    except ValueError as exc:  # pragma: no cover - invalid data
+        raise InvalidBlockRow() from exc
+
+    if start_dt is None or end_dt is None or start_dt >= end_dt:
+        raise InvalidBlockRow()
+
+    start_dt = quantize(start_dt, up=False)
+    end_dt = quantize(end_dt, up=True)
+
+    title = (data.get("title") or "").strip() or None
+
+    return Block(id=uuid.uuid4().hex, start_utc=start_dt, end_utc=end_dt, title=title)
+
+
+def fetch_blocks_from_sheet(spreadsheet_id: str, cell_range: str) -> list[Block]:
+    """Return blocks fetched from Google Sheets."""
+
+    global _BLOCK_CACHE
+
+    now = time.time()
+    if _BLOCK_CACHE is not None:
+        blocks, expiry = _BLOCK_CACHE
+        if now < expiry:
+            return blocks
+
+    encoded_range = parse.quote(cell_range, safe="")
+    url = (
+        "https://sheets.googleapis.com/v4/spreadsheets/"
+        f"{spreadsheet_id}/values/{encoded_range}"
+    )
+
+    req = request.Request(url)
+    try:
+        with request.urlopen(req) as resp:  # pragma: no cover - network stubbed
+            data = json.loads(resp.read().decode())
+    except HTTPError as e:  # pragma: no cover - network stubbed
+        if e.code in (401, 403):
+            raise GoogleAPIUnauthorized() from e
+        raise
+
+    rows = data.get("values", [])
+    blocks: list[Block] = []
+    if rows:
+        headers = [str(h).strip().lower() for h in rows[0]]
+        for row in rows[1:]:
+            item = {headers[i]: row[i] for i in range(min(len(headers), len(row)))}
+            blocks.append(_to_block(item))
+
+    cache_sec = 300
+    if config_module is not None:
+        cache_sec = config_module.cfg.SHEETS_CACHE_SEC
+    _BLOCK_CACHE = (blocks, now + cache_sec)
+    return blocks
+
+
+# blocks sheet cache: list of Block objects and expiry timestamp
+_BLOCK_CACHE: tuple[list[Block], float] | None = None
 
 
 class GoogleClient:
@@ -94,9 +170,7 @@ class GoogleClient:
                 "singleEvents": "true",
             }
         )
-        url = (
-            "https://www.googleapis.com/calendar/v3/calendars/primary/events?" + query
-        )
+        url = "https://www.googleapis.com/calendar/v3/calendars/primary/events?" + query
         req = request.Request(url, headers={"Authorization": f"Bearer {token}"})
         try:
             with request.urlopen(req) as resp:  # pragma: no cover - network stubbed
@@ -106,7 +180,6 @@ class GoogleClient:
                 raise GoogleAPIUnauthorized() from e
             raise
         return data.get("items", [])
-
 
     def _to_event(self, data: dict) -> Event:
         """Convert a Google Calendar event dictionary to an :class:`Event`."""
@@ -151,8 +224,8 @@ class GoogleClient:
             local_start = tz.localize(datetime.combine(date.date(), time.min))
         else:
             # すでに aware なら JST に合わせる
-            local_start = (
-                date.astimezone(tz).replace(hour=0, minute=0, second=0, microsecond=0)
+            local_start = date.astimezone(tz).replace(
+                hour=0, minute=0, second=0, microsecond=0
             )
 
         start = local_start.astimezone(timezone.utc)
@@ -198,4 +271,10 @@ class GoogleClient:
         return events
 
 
-__all__ = ["GoogleClient", "GoogleAPIUnauthorized", "APIError", "SCOPES"]
+__all__ = [
+    "GoogleClient",
+    "GoogleAPIUnauthorized",
+    "APIError",
+    "SCOPES",
+    "fetch_blocks_from_sheet",
+]

--- a/tests/unit/test_google_client_blocks_sheet.py
+++ b/tests/unit/test_google_client_blocks_sheet.py
@@ -1,4 +1,8 @@
 import json
+import importlib
+from datetime import datetime, timezone, timedelta
+
+from freezegun import freeze_time
 
 
 class DummyResponse:
@@ -15,13 +19,12 @@ class DummyResponse:
         return False
 
 
-def _setup(monkeypatch, rows):
-    import importlib
+def _setup(monkeypatch, rows, cache_sec=60):
     import schedule_app.config as config_module
 
     monkeypatch.setenv("BLOCKS_SHEET_ID", "sheet-id")
     monkeypatch.setenv("SHEETS_BLOCK_RANGE", "Blocks!A2:C")
-    monkeypatch.setenv("SHEETS_CACHE_SEC", "60")
+    monkeypatch.setenv("SHEETS_CACHE_SEC", str(cache_sec))
 
     importlib.reload(config_module)
 
@@ -29,12 +32,77 @@ def _setup(monkeypatch, rows):
 
     gc.config_module = config_module
     gc._BLOCK_CACHE = None
-    monkeypatch.setattr(gc.request, "urlopen", lambda req: DummyResponse({"values": rows}))
 
-    return gc
+    class DummyURL:
+        def __init__(self, rows):
+            self.rows = rows
+            self.calls = 0
+
+        def __call__(self, req):  # pragma: no cover - simple stub
+            self.calls += 1
+            return DummyResponse({"values": self.rows})
+
+    service = DummyURL(rows)
+    monkeypatch.setattr(gc.request, "urlopen", service)
+
+    return gc, service
 
 
 def test_setup_reload(monkeypatch):
-    gc = _setup(monkeypatch, [])
+    gc, _service = _setup(monkeypatch, [])
     assert gc.config_module.cfg.BLOCKS_SHEET_ID == "sheet-id"
     assert gc._BLOCK_CACHE is None
+
+
+def test_fetch_blocks_basic(monkeypatch):
+    rows = [
+        ["start_utc", "end_utc", "title"],
+        ["2025-01-01T00:03:00Z", "2025-01-01T00:31:00Z", "B1"],
+        ["2025-01-01T01:00:00", "2025-01-01T01:10:00", ""],
+    ]
+
+    gc, service = _setup(monkeypatch, rows)
+    blocks = gc.fetch_blocks_from_sheet("sheet-id", "Blocks!A2:C")
+
+    assert service.calls == 1
+    assert len(blocks) == 2
+    b1 = blocks[0]
+    assert b1.start_utc == datetime(2025, 1, 1, 0, 0, tzinfo=timezone.utc)
+    assert b1.end_utc == datetime(2025, 1, 1, 0, 40, tzinfo=timezone.utc)
+    assert b1.title == "B1"
+    assert blocks[1].title is None
+
+
+def test_fetch_blocks_cache(monkeypatch):
+    rows1 = [["start_utc", "end_utc"], ["2025-01-01T00:00:00Z", "2025-01-01T00:10:00Z"]]
+
+    with freeze_time("2025-01-01T00:00:00Z") as frozen:
+        gc, service1 = _setup(monkeypatch, rows1, cache_sec=10)
+        blocks1 = gc.fetch_blocks_from_sheet("sheet-id", "Blocks!A2:C")
+        assert service1.calls == 1
+
+        rows2 = [
+            ["start_utc", "end_utc"],
+            ["2025-01-01T01:00:00Z", "2025-01-01T01:10:00Z"],
+        ]
+
+        class DummyURL:
+            def __init__(self, rows):
+                self.rows = rows
+                self.calls = 0
+
+            def __call__(self, req):  # pragma: no cover - simple stub
+                self.calls += 1
+                return DummyResponse({"values": self.rows})
+
+        service2 = DummyURL(rows2)
+        monkeypatch.setattr(gc.request, "urlopen", service2)
+
+        blocks2 = gc.fetch_blocks_from_sheet("sheet-id", "Blocks!A2:C")
+        assert service2.calls == 0
+        assert blocks2 == blocks1
+
+        frozen.tick(delta=timedelta(seconds=11))
+        blocks3 = gc.fetch_blocks_from_sheet("sheet-id", "Blocks!A2:C")
+        assert service2.calls == 1
+        assert blocks3 != blocks1


### PR DESCRIPTION
## Summary
- implement `fetch_blocks_from_sheet` in `google_client`
- parse sheet rows into `Block` instances with rounding
- cache block data in memory
- extend unit tests for sheet block fetching

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_68772cf2ccdc832d8a0252a615e95917