### PR TITLE
Implement POST /api/blocks/import

### DIFF
--- a/schedule_app/api/blocks.py
+++ b/schedule_app/api/blocks.py
@@ -106,6 +106,19 @@ def import_blocks() -> Response:
     return jsonify([_block_to_dict(b) for b in blocks])
 
 
+@blocks_bp.post("/import")
+def import_blocks_post() -> Response:
+    """POST /api/blocks/import → 204"""
+
+    blocks = _load_sheet_blocks()
+
+    BLOCKS.clear()
+    for b in blocks:
+        BLOCKS[b.id] = b
+
+    return ("", 204)
+
+
 @blocks_bp.post("")
 def create_block() -> tuple[Response, int, dict[str, str]]:
     """POST /api/blocks → 201 Block + Location"""


### PR DESCRIPTION
## Summary
- implement POST `/api/blocks/import` to replace stored blocks with those fetched from Sheets
- test that the endpoint replaces existing blocks and handles errors

## Testing
- `ruff check tests/integration/test_blocks.py schedule_app/api/blocks.py`
- `pytest -q tests/integration/test_blocks.py::test_import_blocks_post_replace -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_687731ea5a6c832d91afd245b90118d1