### PR TITLE
Add Blocks tab with panel toggle

### DIFF
--- a/schedule_app/static/css/styles.css
+++ b/schedule_app/static/css/styles.css
@@ -195,3 +195,24 @@
   color: #111827;                 /* text-gray-900 */
 }
 
+/* --------------------------------------------------------------------------
+   Utility classes required for tests (subset of Tailwind)
+   These are defined here so the app works without the Tailwind CDN.
+   -------------------------------------------------------------------------- */
+
+.hidden {
+  display: none !important;
+}
+
+.border-b-2 {
+  border-bottom-width: 2px;
+}
+
+.border-blue-600 {
+  border-color: #2563eb;
+}
+
+.border-transparent {
+  border-color: transparent;
+}
+

--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -241,6 +241,40 @@ document.addEventListener('DOMContentLoaded', () => {
   loadAndRenderTasks();
 });
 
+// ---------------------------------------------------------------------------
+// Simple tab switching for Tasks / Blocks panels
+// ---------------------------------------------------------------------------
+document.addEventListener('DOMContentLoaded', () => {
+  const buttons = document.querySelectorAll('[data-tab]');
+  const panes = {
+    'task-pane': document.getElementById('task-pane'),
+    'blocks-panel': document.getElementById('blocks-panel'),
+  };
+
+  function activate(id) {
+    for (const [pid, el] of Object.entries(panes)) {
+      if (!el) continue;
+      if (pid === id) {
+        el.classList.remove('hidden');
+      } else {
+        el.classList.add('hidden');
+      }
+    }
+
+    buttons.forEach((btn) => {
+      const active = btn.dataset.tab === id;
+      btn.classList.toggle('border-blue-600', active);
+      btn.classList.toggle('border-transparent', !active);
+    });
+  }
+
+  buttons.forEach((btn) => {
+    btn.addEventListener('click', () => activate(btn.dataset.tab));
+  });
+
+  activate('task-pane');
+});
+
 // Sheets Import button handler
 document.addEventListener('DOMContentLoaded', () => {
   const btnImport = document.getElementById('btn-import-sheets');

--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -60,6 +60,17 @@
             class="ml-2 border rounded px-3 py-1 text-sm bg-gray-600 text-white hover:bg-gray-700 active:translate-y-0.5">
       Clear Cache
     </button>
+
+    <div class="ml-4 space-x-2">
+      <button data-tab="task-pane" id="tab-tasks" type="button"
+              class="tab-btn border-b-2 border-blue-600 px-2 py-1 text-sm">
+        Tasks
+      </button>
+      <button data-tab="blocks-panel" id="tab-blocks" type="button"
+              class="tab-btn border-b-2 border-transparent px-2 py-1 text-sm">
+        Blocks
+      </button>
+    </div>
   </header>
 <!-- ─────────── All-day timeline ─────────── -->
 <section
@@ -95,6 +106,12 @@
         <button type="button" class="delete-task ml-2 border rounded px-1 text-xs">削除</button>
       </div>
     </template>
+  </aside>
+
+  <aside id="blocks-panel"
+         class="w-60 shrink-0 border-r border-gray-300 pr-4 space-y-2 overflow-y-auto hidden"
+         aria-label="Blocks list">
+    <p class="text-gray-500 text-sm">No blocks</p>
   </aside>
 
   <!-- ── time grid ─────────────────────────────────────────────────── -->

--- a/tests/e2e/print_visibility.spec.ts
+++ b/tests/e2e/print_visibility.spec.ts
@@ -7,7 +7,7 @@ test('header and toolbar buttons hidden when printing', async ({ page }) => {
   await expect(header).toBeVisible();
 
   const buttons = header.locator('button');
-  await expect(buttons).toHaveCount(6);
+  await expect(buttons).toHaveCount(8);
   for (let i = 0; i < await buttons.count(); i++) {
     await expect(buttons.nth(i)).toBeVisible();
   }

--- a/tests/e2e/tab_switch.spec.ts
+++ b/tests/e2e/tab_switch.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+// Ensure clicking Tasks/Blocks tabs toggles the panels
+
+test('side pane tabs toggle visibility', async ({ page }) => {
+  await page.goto('/');
+
+  const taskPane = page.locator('#task-pane');
+  const blocksPane = page.locator('#blocks-panel');
+
+  await expect(taskPane).toBeVisible();
+  await expect(blocksPane).toBeHidden();
+
+  await page.locator('[data-tab="blocks-panel"]').click();
+  await expect(blocksPane).toBeVisible();
+  await expect(taskPane).toBeHidden();
+
+  await page.locator('[data-tab="task-pane"]').click();
+  await expect(taskPane).toBeVisible();
+  await expect(blocksPane).toBeHidden();
+});


### PR DESCRIPTION
## Summary
- add Tasks/Blocks tab buttons and blocks panel to index.html
- implement tab switching logic in app.js
- adjust print_visibility button count
- add e2e test for tab switching

## Testing
- `ruff check .`
- `pytest -q` *(fails: freezegun not installed)*
- `npx playwright test` *(fails: cannot install playwright)*

------
https://chatgpt.com/codex/tasks/task_e_687740112564832da2dda107a1151e19