### PR TITLE
Implement blocks fetch on initial load

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -328,11 +328,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   try {
     await loadAndRenderTasks();
   } finally {
-    try {
-      await Alpine.store('blocks').fetch();
-    } catch (err) {
-      console.error('[blocks] failed to load', err);
-      showToast(err.message ?? err);
+    if (window.Alpine) {
+      try {
+        await Alpine.store('blocks').fetch();
+      } catch (err) {
+        console.error('[blocks] failed to load', err);
+        showToast(err.message ?? err);
+      }
     }
   }
 });


### PR DESCRIPTION
## Summary
- fetch tasks on DOMContentLoaded and then load blocks
- toast errors on failing to load blocks

## Testing
- `pytest -q` *(fails: freezegun is required)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877481d2148832d9c47c5938aadfd73