### PR TITLE
Add block modal and FAB

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -1066,3 +1066,59 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 });
 
+
+document.addEventListener('DOMContentLoaded', () => {
+  const btnAdd    = document.getElementById('btn-add-block');
+  const modal     = document.getElementById('block-modal');
+  const form      = document.getElementById('block-form');
+  const btnCancel = document.getElementById('block-cancel');
+
+  function openBlockModal() {
+    modal.showModal();
+    const first = modal.querySelector('input, select, textarea');
+    first?.focus();
+  }
+
+  if (!btnAdd || !modal || !form) return;
+
+  btnAdd.addEventListener('click', () => {
+    form.reset();
+    form.querySelectorAll('[aria-invalid]')
+        .forEach(el => el.removeAttribute('aria-invalid'));
+    openBlockModal();
+  });
+
+  btnCancel?.addEventListener('click', () => {
+    modal.close();
+  });
+
+  modal.addEventListener('close', () => {
+    form.querySelectorAll('[aria-invalid]')
+        .forEach(el => el.removeAttribute('aria-invalid'));
+  });
+
+  modal.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      modal.close();
+    }
+  });
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    if (window.Alpine) {
+      const payload = {
+        title: document.getElementById('block-title').value.trim(),
+        start: document.getElementById('block-start').value,
+        end: document.getElementById('block-end').value,
+      };
+      try {
+        await Alpine.store('blocks').create(payload);
+      } catch (err) {
+        console.error('block create failed', err);
+      }
+    }
+    modal.close();
+    form.reset();
+  });
+});

--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -147,6 +147,10 @@
   </section>
 </main>
 
+  <button id="btn-add-block" aria-label="Add block" class="fixed bottom-4 right-4 p-4 rounded-full bg-blue-600 text-white shadow">
+    ＋
+  </button>
+
   <!-- タスク追加・編集モーダル -->
   <dialog id="task-modal" class="p-4 rounded-lg shadow-md">
     <form id="task-form" method="dialog" class="space-y-2">
@@ -192,6 +196,27 @@
         </button>
         <button type="button" id="task-cancel"
                 class="border rounded px-3 py-1 text-sm">キャンセル</button>
+      </div>
+    </form>
+  </dialog>
+
+  <dialog id="block-modal" class="p-4 rounded-lg shadow-md">
+    <form id="block-form" method="dialog" class="space-y-2">
+      <label class="block">
+        <span class="text-sm">タイトル</span>
+        <input id="block-title" name="title" type="text" class="border rounded w-full p-1 text-sm" />
+      </label>
+      <label class="block">
+        <span class="text-sm">開始時刻</span>
+        <input id="block-start" name="start" type="time" class="border rounded w-full p-1 text-sm" required />
+      </label>
+      <label class="block">
+        <span class="text-sm">終了時刻</span>
+        <input id="block-end" name="end" type="time" class="border rounded w-full p-1 text-sm" required />
+      </label>
+      <div class="flex justify-end gap-2 pt-2">
+        <button type="submit" class="border rounded px-3 py-1 text-sm bg-blue-600 text-white hover:bg-blue-700">保存</button>
+        <button type="button" id="block-cancel" class="border rounded px-3 py-1 text-sm">キャンセル</button>
       </div>
     </form>
   </dialog>

--- a/tests/e2e/block_modal.spec.ts
+++ b/tests/e2e/block_modal.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+// Verify floating add block button opens the modal
+
+test('add block button opens modal', async ({ page }) => {
+  await page.goto('/');
+
+  const btn = page.locator('#btn-add-block');
+  await expect(btn).toBeVisible();
+  await expect(btn).toHaveClass(/fixed/);
+  await expect(btn).toHaveClass(/bottom-4/);
+  await expect(btn).toHaveClass(/right-4/);
+
+  await btn.click();
+  await expect(page.locator('#block-modal')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add floating action button for blocks
- implement new block modal with form fields
- wire modal open/close logic in JS
- call blocks store on save
- test the new button and modal

## Testing
- `pytest -q` *(fails: freezegun missing)*
- `npx playwright test tests/e2e/block_modal.spec.ts --reporter dot` *(fails: offline)*

------
https://chatgpt.com/codex/tasks/task_e_6877549dbc38832d975371e41799deed