### PR TITLE
Fix block modal validation

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -1141,6 +1141,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
+    // method="dialog" forms skip built-in validation, so trigger it manually
+    if (!form.reportValidity()) {
+      return;
+    }
+
     if (window.Alpine) {
       const payload = {
         title: document.getElementById('block-title').value.trim(),


### PR DESCRIPTION
## Summary
- validate block form inputs using `form.reportValidity()` before constructing the payload
- comment why validation is triggered manually

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q` *(fails: freezegun is required)*

------
https://chatgpt.com/codex/tasks/task_e_68775855314c832dbbbfcab9040a732a