### PR TITLE
Handle block deletion via store

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -1169,11 +1169,15 @@ document.addEventListener('DOMContentLoaded', () => {
   list?.addEventListener('click', async (e) => {
     const btn = e.target.closest('.delete-block');
     if (!btn) return;
+
     const item = btn.closest('li');
     if (!item) return;
+
     const id = item.dataset.blockId;
     if (!id) return;
+
     if (!confirm('このブロックを削除しますか?')) return;
+
     try {
       if (window.Alpine) {
         await Alpine.store('blocks').remove(id);
@@ -1181,6 +1185,9 @@ document.addEventListener('DOMContentLoaded', () => {
     } catch (err) {
       console.error('block delete failed', err);
     }
-    modal.close();
+
+    if (modal.open) {
+      modal.close();
+    }
   });
 });

--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -1165,4 +1165,22 @@ document.addEventListener('DOMContentLoaded', () => {
     modal.close();
     form.reset();
   });
+
+  list?.addEventListener('click', async (e) => {
+    const btn = e.target.closest('.delete-block');
+    if (!btn) return;
+    const item = btn.closest('li');
+    if (!item) return;
+    const id = item.dataset.blockId;
+    if (!id) return;
+    if (!confirm('このブロックを削除しますか?')) return;
+    try {
+      if (window.Alpine) {
+        await Alpine.store('blocks').remove(id);
+      }
+    } catch (err) {
+      console.error('block delete failed', err);
+    }
+    modal.close();
+  });
 });

--- a/tests/e2e/block_delete.spec.ts
+++ b/tests/e2e/block_delete.spec.ts
@@ -5,23 +5,22 @@ import { test, expect } from '@playwright/test';
 test('delete block removes list item', async ({ page }) => {
   await page.goto('/');
 
-  // Ensure a block exists via Alpine store
+  // Wait for Alpine store to be ready then inject a block
+  await page.waitForFunction(() => (window as any).Alpine && (window as any).Alpine.store('blocks'));
   await page.evaluate(() => {
-    const store = window.Alpine?.store('blocks');
-    if (store) {
-      store.data = [{
-        id: 'b1',
-        title: 'Demo Block',
-        start_utc: '2025-01-01T00:00:00Z',
-        end_utc: '2025-01-01T01:00:00Z'
-      }];
-    }
+    const store = (window as any).Alpine!.store('blocks');
+    store.data = [{
+      id: 'b1',
+      title: 'Demo Block',
+      start_utc: '2025-01-01T00:00:00Z',
+      end_utc: '2025-01-01T01:00:00Z'
+    }];
   });
 
   await page.locator('[data-tab="blocks-panel"]').click();
 
   const item = page.locator('#block-list li').filter({ hasText: 'Demo Block' });
-  await expect(item).toBeVisible();
+  await expect(item).toBeVisible({ timeout: 5000 });
 
   page.once('dialog', d => d.accept());
   await item.locator('.delete-block').click();

--- a/tests/e2e/block_delete.spec.ts
+++ b/tests/e2e/block_delete.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+// Deleting a block from the list triggers confirmation and removal
+
+test('delete block removes list item', async ({ page }) => {
+  await page.goto('/');
+
+  // Ensure a block exists via Alpine store
+  await page.evaluate(() => {
+    const store = window.Alpine?.store('blocks');
+    if (store) {
+      store.data = [{
+        id: 'b1',
+        title: 'Demo Block',
+        start_utc: '2025-01-01T00:00:00Z',
+        end_utc: '2025-01-01T01:00:00Z'
+      }];
+    }
+  });
+
+  await page.locator('[data-tab="blocks-panel"]').click();
+
+  const item = page.locator('#block-list li').filter({ hasText: 'Demo Block' });
+  await expect(item).toBeVisible();
+
+  page.once('dialog', d => d.accept());
+  await item.locator('.delete-block').click();
+
+  await expect(page.locator('#block-list li')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- listen for delete clicks in block list
- update Alpine store and close modal on delete
- add e2e test covering block deletion

## Testing
- `npm run test:e2e --silent` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68775a1b1600832d801524cfa1039d34