### PR TITLE
Add block delete e2e test

### DIFF
--- a/tests/e2e/block_delete.spec.ts
+++ b/tests/e2e/block_delete.spec.ts
@@ -16,6 +16,9 @@ test('delete block removes list item', async ({ page }) => {
 
   await page.goto('/');
 
+  // Switch to the Blocks tab so the panel is visible
+  await page.locator('[data-tab="blocks-panel"]').click();
+
   // Inject a fake block entry for testing
   await page.evaluate(() => {
     const list = document.querySelector('#block-list');


### PR DESCRIPTION
## Summary
- add a new Playwright spec testing removal of a block element
- setup Alpine stub via `addInitScript`
- insert a list item and verify it disappears after confirming deletion

## Testing
- `npm run test:e2e` *(fails: playwright not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687762bcafac832dabefc4c91e1fcd37