### PR TITLE
Add Playwright instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ pip install -r requirements.dev.txt
 pytest -q
 ```
 
+## End-to-End Tests
+
+Playwright is listed under `devDependencies` and must be installed with `npm install` before running the browser tests.
+
+```bash
+npm install
+npm run test:e2e
+```
+
 
 ## Tasks API
 


### PR DESCRIPTION
## Summary
- document Playwright dev dependency
- show how to run e2e tests with npm

## Testing
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68776ef9ffb4832db8ea502b444d7ff8