### PR TITLE
Add CLI shell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ python -m venv .venv
 python -m pip install -U pip
 pip install -r requirements.dev.txt  # installs dev packages like freezegun
 pre-commit install
+python -m schedule_app.cli shell  # interactive shell
 flask --app schedule_app run --debug --port 5173
 ```
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -65,6 +65,7 @@ python -m venv .venv
 python -m pip install -U pip
 pip install -r requirements.dev.txt
 pre-commit install
+python -m schedule_app.cli shell
 flask --app schedule_app run --debug --port 5173
 ```
 

--- a/schedule_app/cli.py
+++ b/schedule_app/cli.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import code
+import click
+
+from schedule_app import create_app
+
+@click.group(help="Schedule App management commands")
+def cli() -> None:
+    pass
+
+
+@cli.command()
+def shell() -> None:
+    """Start an interactive Python shell."""
+    ns = {"create_app": create_app}
+    click.echo("Starting interactive shell...")
+    code.interact(local=ns)
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,12 @@
+from schedule_app.cli import shell
+import code
+
+def test_shell_invokes_interact(monkeypatch):
+    called = {}
+
+    def fake_interact(*, local=None):
+        called['local'] = local
+
+    monkeypatch.setattr(code, 'interact', fake_interact)
+    shell()
+    assert 'create_app' in called['local']


### PR DESCRIPTION
## Summary
- expose an interactive shell via `python -m schedule_app.cli`
- document the new command
- test the shell helper

## Testing
- `ruff check schedule_app/cli.py tests/unit/test_cli.py`
- `pytest -q` *(fails: freezegun not installed)*
- `pre-commit run --files schedule_app/cli.py README.md SPEC.md tests/unit/test_cli.py` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687771146d34832dbac7ae937b4bec31