### PR TITLE
Implement block creation via API

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -187,11 +187,19 @@ document.addEventListener('alpine:init', () => {
     async create(payload) {
       this.isLoading = true;
       try {
-        // TODO: POST /api/blocks
-        // const block = await apiFetch('/api/blocks', { method: 'POST', body: JSON.stringify(payload) });
-        const block = payload;
+        const block = await apiFetch('/api/blocks', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
         this.data.push(block);
-        window.dispatchEvent(new CustomEvent('blocks:created', { detail: block }));
+        window.dispatchEvent(
+          new CustomEvent('blocks:created', { detail: block })
+        );
+      } catch (err) {
+        console.error('[blocks] create failed', err);
+        showToast(err.message ?? err);
+        throw err;
       } finally {
         this.isLoading = false;
       }


### PR DESCRIPTION
## Summary
- wire store.blocks.create to POST /api/blocks
- push the returned block into the local list
- display error toast on failure

## Testing
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_687793ac499c832db8af5c84997f2ec1