### PR TITLE
Add blocks import dialog and end-to-end test

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -430,6 +430,48 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 });
 
+// Blocks import button handler
+document.addEventListener('DOMContentLoaded', () => {
+  const btnImport = document.getElementById('btn-import-blocks');
+  const dialog = document.getElementById('blocks-import-dialog');
+  if (!btnImport || !dialog) return;
+
+  const spanCount = dialog.querySelector('#blocks-import-count');
+  const btnOk = dialog.querySelector('#blocks-import-ok');
+  const btnCancel = dialog.querySelector('#blocks-import-cancel');
+
+  btnImport.addEventListener('click', async () => {
+    if (!window.Alpine) return;
+    try {
+      const blocks = await Alpine.store('blocks').importPreview();
+      if (spanCount) spanCount.textContent = String(blocks.length);
+      dialog.showModal();
+    } catch (err) {
+      console.error('blocks import preview failed', err);
+    }
+  });
+
+  btnOk?.addEventListener('click', async (e) => {
+    e.preventDefault();
+    if (!window.Alpine) return dialog.close();
+    try {
+      await Alpine.store('blocks').importReplace();
+    } catch (err) {
+      console.error('blocks import failed', err);
+    }
+    dialog.close();
+  });
+
+  const close = () => dialog.close();
+  btnCancel?.addEventListener('click', close);
+  dialog.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+    }
+  });
+});
+
 // Ensure a time grid exists for tests or pages missing it
 document.addEventListener('DOMContentLoaded', () => {
   if (document.querySelector('#time-grid')) return;

--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -112,6 +112,12 @@
          x-data="{ get blocks() { return $store.blocks?.data || [] } }"
          class="w-60 shrink-0 border-r border-gray-300 pr-4 space-y-2 hidden"
          aria-label="Blocks list">
+    <header class="flex justify-end">
+      <button id="btn-import-blocks" type="button"
+              class="border rounded px-3 py-1 text-sm bg-purple-600 text-white hover:bg-purple-700 active:translate-y-0.5">
+        Import from Sheets
+      </button>
+    </header>
     <p class="text-gray-500 text-sm" x-show="!blocks.length">No blocks</p>
     <ul id="block-list" role="list" class="space-y-2 max-h-80 overflow-y-auto" x-show="blocks.length">
       <template x-for="block in blocks" :key="block.id">
@@ -221,6 +227,18 @@
       <div class="flex justify-end gap-2 pt-2">
         <button type="submit" class="border rounded px-3 py-1 text-sm bg-blue-600 text-white hover:bg-blue-700">Save</button>
         <button type="button" id="block-cancel" class="border rounded px-3 py-1 text-sm">Cancel</button>
+      </div>
+    </form>
+  </dialog>
+
+  <dialog id="blocks-import-dialog" class="p-4 rounded-lg shadow-md">
+    <form id="blocks-import-form" method="dialog" class="space-y-2">
+      <p><span id="blocks-import-count">0</span> blocks will be imported.</p>
+      <div class="flex justify-end gap-2 pt-2">
+        <button type="submit" id="blocks-import-ok"
+                class="border rounded px-3 py-1 text-sm bg-blue-600 text-white hover:bg-blue-700">OK</button>
+        <button type="button" id="blocks-import-cancel"
+                class="border rounded px-3 py-1 text-sm">Cancel</button>
       </div>
     </form>
   </dialog>

--- a/tests/e2e/blocks_import.spec.ts
+++ b/tests/e2e/blocks_import.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+// Import blocks from Sheets via dialog
+
+test('blocks import dialog shows preview count and triggers replace', async ({ page }) => {
+  await page.addInitScript(() => {
+    // Minimal Alpine store stub
+    (window as any).Alpine = {
+      stores: {
+        blocks: {
+          async importPreview() {
+            return [{ id: 'b1' }, { id: 'b2' }];
+          },
+          async importReplace() {
+            (window as any).replaceCalled = true;
+          },
+          data: []
+        }
+      },
+      store(name: string) { return (this as any).stores[name]; }
+    } as any;
+    window.dispatchEvent(new Event('alpine:init'));
+  });
+
+  await page.goto('/');
+
+  await page.locator('[data-tab="blocks-panel"]').click();
+  await page.locator('#btn-import-blocks').click();
+
+  const dialog = page.locator('#blocks-import-dialog');
+  await expect(dialog).toBeVisible();
+  await expect(dialog.locator('#blocks-import-count')).toHaveText('2');
+
+  await dialog.locator('#blocks-import-ok').click();
+  await expect(dialog).not.toBeVisible();
+
+  const called = await page.evaluate(() => (window as any).replaceCalled === true);
+  expect(called).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add Import from Sheets button to Blocks panel
- create confirmation dialog for block import
- implement preview/replace logic in JS
- test block import dialog via Playwright

## Testing
- `npm run test:e2e` *(fails: playwright not installed)*
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_68779dedf760832da8d985c98d113f6c