### PR TITLE
Fix header selector in print visibility test

### DIFF
--- a/tests/e2e/print_visibility.spec.ts
+++ b/tests/e2e/print_visibility.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 test('header and toolbar buttons hidden when printing', async ({ page }) => {
   await page.goto('/');
 
-  const header = page.locator('header');
+  const header = page.locator('body > header');
   await expect(header).toBeVisible();
 
   const buttons = header.locator('button');


### PR DESCRIPTION
## Summary
- target the main page header using `body > header`

## Testing
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877a2f4917c832dbaa86c0cca0085b9