### PR TITLE
Implement Blocks import preview UI

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -430,6 +430,27 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 });
 
+// Blocks import button handler
+document.addEventListener('DOMContentLoaded', () => {
+  const btnImport = document.getElementById('btn-import-blocks');
+  if (!btnImport) return;
+  btnImport.addEventListener('click', async () => {
+    if (!window.Alpine) return;
+    const store = Alpine.store('blocks');
+    if (!store || typeof store.importPreview !== 'function') return;
+    try {
+      const preview = await store.importPreview();
+      const count = Array.isArray(preview) ? preview.length : 0;
+      if (confirm(`Import ${count} blocks from Sheets?`)) {
+        await store.importReplace();
+      }
+    } catch (err) {
+      console.error('blocks import failed', err);
+      alert(err.message ?? err);
+    }
+  });
+});
+
 // Ensure a time grid exists for tests or pages missing it
 document.addEventListener('DOMContentLoaded', () => {
   if (document.querySelector('#time-grid')) return;

--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -112,6 +112,12 @@
          x-data="{ get blocks() { return $store.blocks?.data || [] } }"
          class="w-60 shrink-0 border-r border-gray-300 pr-4 space-y-2 hidden"
          aria-label="Blocks list">
+    <header class="flex justify-end">
+      <button id="btn-import-blocks" type="button"
+              class="border rounded px-3 py-1 text-sm bg-purple-600 text-white hover:bg-purple-700 active:translate-y-0.5">
+        Import from Sheets
+      </button>
+    </header>
     <p class="text-gray-500 text-sm" x-show="!blocks.length">No blocks</p>
     <ul id="block-list" role="list" class="space-y-2 max-h-80 overflow-y-auto" x-show="blocks.length">
       <template x-for="block in blocks" :key="block.id">


### PR DESCRIPTION
## Summary
- add `Import from Sheets` button to blocks panel
- trigger confirmation dialog before calling `store.blocks.importReplace`

## Testing
- `pytest -q`
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_6877a58b716c832da1c0bd6654483da6