### PR TITLE
Implement blocks import replace

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -264,10 +264,22 @@ document.addEventListener('alpine:init', () => {
     async importReplace() {
       this.isLoading = true;
       try {
-        // TODO: POST /api/blocks/import
-        // await apiFetch('/api/blocks/import', { method: 'POST' });
+        await apiFetch('/api/blocks/import', { method: 'POST' });
         window.dispatchEvent(new CustomEvent('blocks:import-replace'));
         await this.fetch();
+        const input = document.querySelector('#input-date');
+        const ymd = input ? input.value : todayUtcISO();
+        if (ymd) {
+          try {
+            await generateSchedule(ymd);
+          } catch (err) {
+            console.error('[blocks] grid refresh failed', err);
+          }
+        }
+      } catch (err) {
+        console.error('[blocks] import replace failed', err);
+        showToast(err.message ?? err);
+        throw err;
       } finally {
         this.isLoading = false;
       }


### PR DESCRIPTION
## Summary
- implement store.blocks.importReplace to POST `/api/blocks/import`
- refresh blocks list and regenerate schedule grid after importing

## Testing
- `pytest -q` *(fails: freezegun is missing)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877a94d5400832d9464b4d48ccc2e6c