### PR TITLE
Add blocked slot overlay functionality

### DIFF
--- a/schedule_app/static/css/a11y.css
+++ b/schedule_app/static/css/a11y.css
@@ -31,7 +31,8 @@
    ────────────────────────────────────────────────────────── */
 
 .task-card,
-.grid-slot--busy {
+.grid-slot--busy,
+.grid-slot--blocked {
   position: relative;           /* 疑似要素の絶対配置用 */
   isolation: isolate;           /* Safari 対応で z-index 独立 */
 }
@@ -57,6 +58,25 @@
   z-index: 1;                   /* 本体より前面、ドラッグ時は JS 側で上げる */
 }
 
+/* ===== Blocked slot overlay ================================ */
+.grid-slot--blocked::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+
+  background-image: repeating-linear-gradient(
+      135deg,
+      rgba(0, 0, 0, 0.35) 0,
+      rgba(0, 0, 0, 0.35) 4px,
+      transparent 4px,
+      transparent 8px
+  );
+  background-size: 8px 8px;
+  mix-blend-mode: multiply;
+  z-index: 2;
+}
+
 /* 色覚バリアフリー ― Reduced contrast 専用オーバーライド  */
 @media (prefers-contrast: less) {
   .task-card::after,
@@ -71,12 +91,22 @@
       transparent          4px 8px
     );
   }
+
+  .grid-slot--blocked::after {
+    mix-blend-mode: normal;
+    background-image: repeating-linear-gradient(
+      135deg,
+      rgba(0, 0, 0, 0.45) 0 4px,
+      transparent          4px 8px
+    );
+  }
 }
 
 /* Windows High‑Contrast (forced‑colors) も念のため */
 @media (forced-colors: active) {
   .task-card::after,
-  .grid-slot--busy::after {
+  .grid-slot--busy::after,
+  .grid-slot--blocked::after {
     background-image: repeating-linear-gradient(
       135deg,
       CanvasText 0 4px,

--- a/schedule_app/static/css/print.css
+++ b/schedule_app/static/css/print.css
@@ -39,12 +39,14 @@
 @media print {
   /* 斜ストライプを付ける疑似要素を無効化 */
   .grid-slot--busy::after,
+  .grid-slot--blocked::after,
   .task-card::after {
     display: none !important;
   }
 
   /* 以前に付けたストライプ用 background を上書きして消す */
   .grid-slot--busy,
+  .grid-slot--blocked,
   .task-card {
     background-image: none !important;          /* ← ここで完全に無効化 */
     -webkit-print-color-adjust: exact;

--- a/schedule_app/static/css/styles.css
+++ b/schedule_app/static/css/styles.css
@@ -36,6 +36,11 @@
   isolation: isolate;           /* Safari 対応で z-index 独立 */
 }
 
+.grid-slot--blocked {
+  position: relative;
+  isolation: isolate;
+}
+
 /* 疑似要素でストライプを重ねる */
 .task-card::after,
 .grid-slot--busy::after {
@@ -57,6 +62,25 @@
   z-index: 1;                   /* 本体より前面、ドラッグ時は JS 側で上げる */
 }
 
+/* ===== Blocked slot overlay ================================ */
+.grid-slot--blocked::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+
+  background-image: repeating-linear-gradient(
+      135deg,
+      rgba(0, 0, 0, 0.35) 0,
+      rgba(0, 0, 0, 0.35) 4px,
+      transparent 4px,
+      transparent 8px
+  );
+  background-size: 8px 8px;
+  mix-blend-mode: multiply;
+  z-index: 2;
+}
+
 /* 色覚バリアフリー ― Reduced contrast 専用オーバーライド  */
 @media (prefers-contrast: less) {
   .task-card::after,
@@ -71,12 +95,22 @@
       transparent          4px 8px
     );
   }
+
+  .grid-slot--blocked::after {
+    mix-blend-mode: normal;
+    background-image: repeating-linear-gradient(
+      135deg,
+      rgba(0, 0, 0, 0.45) 0 4px,
+      transparent          4px 8px
+    );
+  }
 }
 
 /* Windows High‑Contrast (forced‑colors) も念のため */
 @media (forced-colors: active) {
   .task-card::after,
-  .grid-slot--busy::after {
+  .grid-slot--busy::after,
+  .grid-slot--blocked::after {
     background-image: repeating-linear-gradient(
       135deg,
       CanvasText 0 4px,


### PR DESCRIPTION
## Summary
- style grid blocked slots with diagonal hatch overlays
- ensure blocked slot overlay disabled in print views
- add blocked slot overlay to reduced/forced color CSS
- compute and render blocked slots in the schedule grid
- adjust contrast helper and events

## Testing
- `pytest -q` *(fails: freezegun missing)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_687821b306c8832db76278d7f9a9057b