### PR TITLE
Add ARIA attributes to block modal

### DIFF
--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -210,20 +210,17 @@
     </form>
   </dialog>
 
-  <dialog id="block-modal" class="p-4 rounded-lg shadow-md">
+  <dialog id="block-modal" role="dialog" aria-modal="true" aria-labelledby="block-modal-title" class="p-4 rounded-lg shadow-md">
     <form id="block-form" method="dialog" class="space-y-2">
-      <label class="block">
-        <span class="text-sm">タイトル</span>
-        <input id="block-title" name="title" type="text" class="border rounded w-full p-1 text-sm" />
-      </label>
-      <label class="block">
-        <span class="text-sm">開始時刻</span>
-        <input id="block-start" name="start" type="datetime-local" step="600" class="border rounded w-full p-1 text-sm" required />
-      </label>
-      <label class="block">
-        <span class="text-sm">終了時刻</span>
-        <input id="block-end" name="end" type="datetime-local" step="600" class="border rounded w-full p-1 text-sm" required />
-      </label>
+      <h2 id="block-modal-title" class="text-lg font-semibold mb-2">Block</h2>
+      <label for="block-title" class="block text-sm">タイトル</label>
+      <input id="block-title" name="title" type="text" class="border rounded w-full p-1 text-sm" />
+
+      <label for="block-start" class="block text-sm">開始時刻</label>
+      <input id="block-start" name="start" type="datetime-local" step="600" class="border rounded w-full p-1 text-sm" required />
+
+      <label for="block-end" class="block text-sm">終了時刻</label>
+      <input id="block-end" name="end" type="datetime-local" step="600" class="border rounded w-full p-1 text-sm" required />
       <div class="flex justify-end gap-2 pt-2">
         <button type="submit" class="border rounded px-3 py-1 text-sm bg-blue-600 text-white hover:bg-blue-700">Save</button>
         <button type="button" id="block-cancel" class="border rounded px-3 py-1 text-sm">Cancel</button>


### PR DESCRIPTION
## Summary
- improve accessibility of the blocks modal

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: freezegun is required to run tests)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878420102b0832dafdfa04073542b9a