### PR TITLE
Enhance task modal accessibility

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -1073,7 +1073,9 @@ document.addEventListener('DOMContentLoaded', () => {
    */
   function openModal() {
     modal.showModal();
-    const first = modal.querySelector('input, select, textarea');
+    const first = modal.querySelector(
+      'input:not([type=hidden]):not([disabled]), select:not([disabled]), textarea:not([disabled])'
+    );
     first?.focus();
   }
 

--- a/schedule_app/templates/index.html
+++ b/schedule_app/templates/index.html
@@ -162,42 +162,33 @@
   </button>
 
   <!-- タスク追加・編集モーダル -->
-  <dialog id="task-modal" class="p-4 rounded-lg shadow-md">
+  <dialog id="task-modal" role="dialog" aria-modal="true" aria-labelledby="task-modal-title" class="p-4 rounded-lg shadow-md">
     <form id="task-form" method="dialog" class="space-y-2">
+      <h2 id="task-modal-title" class="text-lg font-semibold mb-2">Task</h2>
       <input type="hidden" id="task-id" name="id" />
 
-      <label class="block">
-        <span class="text-sm">タイトル</span>
-        <input id="task-title" name="title" type="text"
-               class="border rounded w-full p-1 text-sm" required />
-      </label>
+      <label for="task-title" class="block text-sm">タイトル</label>
+      <input id="task-title" name="title" type="text"
+             class="border rounded w-full p-1 text-sm" required />
 
-      <label class="block">
-        <span class="text-sm">カテゴリ</span>
-        <input id="task-category" name="category" type="text"
-               class="border rounded w-full p-1 text-sm" />
-      </label>
+      <label for="task-category" class="block text-sm">カテゴリ</label>
+      <input id="task-category" name="category" type="text"
+             class="border rounded w-full p-1 text-sm" />
 
-      <label class="block">
-        <span class="text-sm">所要時間 (分)</span>
-        <input id="task-duration" name="duration" type="number" min="5" step="5"
-               class="border rounded w-full p-1 text-sm" required />
-      </label>
+      <label for="task-duration" class="block text-sm">所要時間 (分)</label>
+      <input id="task-duration" name="duration" type="number" min="5" step="5"
+             class="border rounded w-full p-1 text-sm" required />
 
-      <label class="block">
-        <span class="text-sm">優先度</span>
-        <select id="task-priority" name="priority"
-                class="border rounded w-full p-1 text-sm">
-          <option value="A">A</option>
-          <option value="B">B</option>
-        </select>
-      </label>
+      <label for="task-priority" class="block text-sm">優先度</label>
+      <select id="task-priority" name="priority"
+              class="border rounded w-full p-1 text-sm">
+        <option value="A">A</option>
+        <option value="B">B</option>
+      </select>
 
-      <label class="block">
-        <span class="text-sm">最速開始時刻</span>
-        <input id="task-earliest" name="earliest_start" type="time"
-               class="border rounded w-full p-1 text-sm" />
-      </label>
+      <label for="task-earliest" class="block text-sm">最速開始時刻</label>
+      <input id="task-earliest" name="earliest_start" type="time"
+             class="border rounded w-full p-1 text-sm" />
 
       <div class="flex justify-end gap-2 pt-2">
         <button type="submit"


### PR DESCRIPTION
## Summary
- add ARIA attributes to the task dialog
- add a dialog title heading
- restructure task form labels
- focus the first usable field when the modal opens

## Testing
- `pip install -r requirements.dev.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: freezegun is required)*
- `npm install` *(fails: 403 Forbidden)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878444c8cf0832d93fa6d3e86bd3baa