### PR TITLE
Blocks toast notifications

### DIFF
--- a/schedule_app/static/js/app.js
+++ b/schedule_app/static/js/app.js
@@ -473,7 +473,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     } catch (err) {
       console.error('blocks import failed', err);
-      alert(err.message ?? err);
+      showToast(err.message ?? err);
     }
   });
 });
@@ -1279,7 +1279,7 @@ document.addEventListener('DOMContentLoaded', () => {
           handled = true;
         } catch (err) {
           console.error('block delete failed', err);
-          alert(err.message ?? err);
+          showToast(err.message ?? err);
           return;
         }
       }


### PR DESCRIPTION
## Summary
- show toast on block import or delete failure

## Testing
- `node --check schedule_app/static/js/app.js`
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_687848844a08832d9f0cfd8953d3dc23