### PR TITLE
Add Playwright test for block UI workflow

### DIFF
--- a/tests/e2e/blocks.spec.ts
+++ b/tests/e2e/blocks.spec.ts
@@ -55,7 +55,7 @@ test('block CRUD and import flow updates grid on mobile', async ({ page, request
 
   // Custom store methods with DOM updates
   await page.evaluate(() => {
-    const store = window.Alpine.store('blocks');
+    const store = window.Alpine.store('blocks', {} as any);
     store.data = [];
     store.fetch = async function () {
       const res = await fetch('/api/blocks');

--- a/tests/e2e/unplaced_overlap.spec.ts
+++ b/tests/e2e/unplaced_overlap.spec.ts
@@ -34,10 +34,9 @@ test('overlap tasks trigger toast and red card', async ({ page, request }) => {
   await page.getByTestId('generate-btn').click();
 
   /* ---- 3. Verify toast appears ---- */
-  const toastText = page.locator('text=/未配置: Overlap[12]/');
-  await expect(toastText).toBeVisible({ timeout: 5000 });
-
   const toast = page.locator('.schedule-toast');
+  await expect(toast).toBeVisible({ timeout: 5000 });
+  await expect(toast).toHaveText(/未配置: Overlap[12]/);
   await expect(toast).toHaveCount(1);
   await expect(toast).toHaveAttribute('role', 'status');
   await expect(toast).toHaveAttribute('aria-live', 'polite');


### PR DESCRIPTION
## Summary
- add `blocks.spec.ts` end-to-end test covering block creation, deletion and Sheets import

## Testing
- `npm run test:e2e` *(fails: playwright not installed)*
- `pytest -q` *(fails: freezegun missing)*

------
https://chatgpt.com/codex/tasks/task_e_687855445e34832da8214c163314dfb1