### PR TITLE
Update mobile block test

### DIFF
--- a/tests/e2e/mobile_block_workflow.spec.ts
+++ b/tests/e2e/mobile_block_workflow.spec.ts
@@ -53,6 +53,10 @@ test('mobile block workflow via modal form', async ({ page, request }) => {
 
   await page.goto('/');
 
+  await page.evaluate(() => {
+    window.dispatchEvent(new Event('alpine:init'));
+  });
+
   // Show the Blocks panel
   await page.locator('[data-tab="blocks-panel"]').click();
 


### PR DESCRIPTION
## Summary
- ensure Alpine initialization fires in mobile block workflow test

## Testing
- `npx playwright test` *(fails: 403 Forbidden when fetching Playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6878840f6364832daa87ffb705b83261