### PR TITLE
Trigger Alpine init in mobile block test

### DIFF
--- a/tests/e2e/mobile_block_workflow.spec.ts
+++ b/tests/e2e/mobile_block_workflow.spec.ts
@@ -52,6 +52,7 @@ test('mobile block workflow via modal form', async ({ page, request }) => {
   }
 
   await page.goto('/');
+  await page.evaluate(() => window.dispatchEvent(new Event('alpine:init')));
 
   // Show the Blocks panel
   await page.locator('[data-tab="blocks-panel"]').click();


### PR DESCRIPTION
## Summary
- trigger Alpine init after navigating to the page in the mobile block workflow test

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687889236738832dac023c868547bac0