### PR TITLE
Add Playwright blocks panel workflow test

### DIFF
--- a/tests/e2e/blocks.spec.ts
+++ b/tests/e2e/blocks.spec.ts
@@ -1,32 +1,74 @@
 import { test, expect } from '@playwright/test';
 
-// Ensure importing blocks triggers schedule refresh
+// Verify blocks panel workflow and import functionality
 
-test('blocks import regenerates schedule', async ({ page }) => {
-  // Avoid calendar redirects
+test('blocks panel create/delete/import updates grid', async ({ page, request }) => {
+  // --- Clear existing blocks via API ---
+  let res = await request.get('/api/blocks');
+  expect(res.ok()).toBeTruthy();
+  const existing = await res.json();
+  for (const b of existing) {
+    const del = await request.delete(`/api/blocks/${b.id}`);
+    expect(del.ok()).toBeTruthy();
+  }
+  res = await request.get('/api/blocks');
+  expect(await res.json()).toEqual([]);
+
+  // --- Network stubs ---
   await page.route('**/api/calendar**', r =>
     r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
   );
 
-  // Stub blocks import endpoints
-  await page.route('**/api/blocks/import', r => r.fulfill({ status: 204 }));
-  await page.route('**/api/blocks', r => {
-    const data = [
-      {
-        id: 'b1',
-        start_utc: '2025-01-01T00:00:00Z',
-        end_utc: '2025-01-01T00:10:00Z',
-      },
-    ];
-    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(data) });
-  });
-
-  await page.route('**/api/schedule/generate**', r => {
+  // predictable schedule grid
+  await page.route('**/api/schedule/generate**', route => {
     const body = JSON.stringify({ date: '2025-01-01', slots: new Array(144).fill(0), unplaced: [] });
-    r.fulfill({ status: 200, contentType: 'application/json', body });
+    route.fulfill({ status: 200, contentType: 'application/json', body });
   });
 
-  // Provide Alpine stub and schedule generator helper
+  const serverBlocks: any[] = [];
+  const imported = [{
+    id: 'imp1',
+    start_utc: '2025-01-01T00:00:00Z',
+    end_utc: '2025-01-01T00:10:00Z',
+  }];
+
+  // stub /api/blocks CRUD
+  await page.route('**/api/blocks**', async route => {
+    const { method, url } = route.request();
+    if (method === 'GET' && url.endsWith('/api/blocks')) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(serverBlocks) });
+      return;
+    }
+    if (method === 'POST' && url.endsWith('/api/blocks')) {
+      const payload = JSON.parse(route.request().postData() || '{}');
+      const block = { id: `b${serverBlocks.length + 1}`, ...payload };
+      serverBlocks.push(block);
+      await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(block) });
+      return;
+    }
+    if (method === 'DELETE') {
+      const m = url.match(/\/api\/blocks\/(.+)$/);
+      if (m) {
+        const idx = serverBlocks.findIndex(b => b.id === m[1]);
+        if (idx !== -1) serverBlocks.splice(idx, 1);
+      }
+      await route.fulfill({ status: 204 });
+      return;
+    }
+    await route.continue();
+  });
+
+  // stub import preview & replace
+  await page.route('**/api/blocks/import', async route => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(imported) });
+    } else {
+      serverBlocks.splice(0, serverBlocks.length, ...imported);
+      await route.fulfill({ status: 204 });
+    }
+  });
+
+  // ---- Alpine store stub ----
   await page.addInitScript(() => {
     window.Alpine = {
       stores: {},
@@ -36,16 +78,11 @@ test('blocks import regenerates schedule', async ({ page }) => {
       },
     } as any;
     window.dispatchEvent(new Event('alpine:init'));
-
-    window.generateSchedule = async (ymd: string) => {
-      await fetch(`/api/schedule/generate?date=${ymd}&algo=greedy`, {
-        method: 'POST',
-      });
-    };
   });
 
   await page.goto('/');
 
+  // define blocks store after scripts load
   await page.evaluate(() => {
     window.Alpine.store('blocks', {
       data: [],
@@ -54,28 +91,95 @@ test('blocks import regenerates schedule', async ({ page }) => {
         this.data = await res.json();
         window.dispatchEvent(new CustomEvent('blocks:fetched', { detail: this.data }));
       },
+      async create(payload: any) {
+        const res = await fetch('/api/blocks', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        const block = await res.json();
+        this.data.push(block);
+        window.dispatchEvent(new CustomEvent('blocks:created', { detail: block }));
+      },
+      async remove(id: string) {
+        await fetch(`/api/blocks/${id}`, { method: 'DELETE' });
+        this.data = this.data.filter((b: any) => b.id !== id);
+        window.dispatchEvent(new CustomEvent('blocks:removed', { detail: id }));
+      },
+      async importPreview() {
+        const res = await fetch('/api/blocks/import');
+        return res.json();
+      },
       async importReplace() {
         await fetch('/api/blocks/import', { method: 'POST' });
-        window.dispatchEvent(new CustomEvent('blocks:import-replace'));
         await this.fetch();
-        const input = document.querySelector('#input-date') as HTMLInputElement | null;
-        const ymd = input?.value;
-        if (ymd) {
-          await window.generateSchedule(ymd);
-        }
+        window.dispatchEvent(new CustomEvent('blocks:import-replace'));
       },
     });
   });
 
+  // set schedule date and generate grid
   await page.evaluate(() => {
     const input = document.getElementById('input-date') as HTMLInputElement;
     input.value = '2025-01-01';
+    input.dispatchEvent(new Event('change', { bubbles: true }));
   });
 
-  const [resp] = await Promise.all([
-    page.waitForResponse(r => r.url().includes('/api/schedule/generate')),
-    page.evaluate(() => window.Alpine.store('blocks').importReplace()),
+  const [genReq] = await Promise.all([
+    page.waitForRequest(r => r.url().includes('/api/schedule/generate')),
+    page.getByTestId('generate-btn').click(),
   ]);
+  expect(genReq.method()).toBe('POST');
 
-  expect(resp.ok()).toBe(true);
+  // ---- create block via modal ----
+  await page.locator('[data-tab="blocks-panel"]').click();
+  await expect(page.locator('#blocks-panel')).toBeVisible();
+
+  await page.locator('#btn-add-block').click();
+  await expect(page.locator('#block-modal')).toBeVisible();
+  await page.fill('#block-start', '2025-01-01T00:00');
+  await page.fill('#block-end', '2025-01-01T00:10');
+
+  const [postReq, postRes] = await Promise.all([
+    page.waitForRequest(r => r.url().endsWith('/api/blocks') && r.method() === 'POST'),
+    page.waitForResponse(r => r.url().endsWith('/api/blocks') && r.request().method() === 'POST'),
+    page.locator('#block-form button[type=submit]').click(),
+  ]);
+  expect(postReq.method()).toBe('POST');
+  expect(postRes.ok()).toBeTruthy();
+
+  const slot0 = page.locator('[data-slot-index="0"]');
+  await expect(slot0).toHaveClass(/grid-slot--blocked/);
+
+  expect(serverBlocks.length).toBe(1);
+  const createdId = serverBlocks[0].id;
+  const item = page.locator(`[data-block-id="${createdId}"]`);
+  await expect(item).toHaveCount(1);
+
+  // ---- delete block ----
+  page.once('dialog', d => d.accept());
+  const [delReq, delRes] = await Promise.all([
+    page.waitForRequest(r => r.url().includes(`/api/blocks/${createdId}`) && r.method() === 'DELETE'),
+    page.waitForResponse(r => r.url().includes(`/api/blocks/${createdId}`) && r.request().method() === 'DELETE'),
+    item.locator('.delete-block').click(),
+  ]);
+  expect(delReq.method()).toBe('DELETE');
+  expect(delRes.ok()).toBeTruthy();
+  await expect(slot0).not.toHaveClass(/grid-slot--blocked/);
+
+  // ---- import from Sheets ----
+  page.once('dialog', d => d.accept());
+  const [getImpReq, postImpReq, getImpRes, postImpRes] = await Promise.all([
+    page.waitForRequest(r => r.url().includes('/api/blocks/import') && r.method() === 'GET'),
+    page.waitForRequest(r => r.url().includes('/api/blocks/import') && r.method() === 'POST'),
+    page.waitForResponse(r => r.url().includes('/api/blocks/import') && r.request().method() === 'GET'),
+    page.waitForResponse(r => r.url().includes('/api/blocks/import') && r.request().method() === 'POST'),
+    page.locator('#btn-import-blocks').click(),
+  ]);
+  expect(getImpReq.method()).toBe('GET');
+  expect(getImpRes.ok()).toBeTruthy();
+  expect(postImpReq.method()).toBe('POST');
+  expect(postImpRes.ok()).toBeTruthy();
+
+  await expect(slot0).toHaveClass(/grid-slot--blocked/);
 });


### PR DESCRIPTION
## Summary
- replace `tests/e2e/blocks.spec.ts` with a new end-to-end test
- test clearing blocks, creating/deleting a block, and importing blocks via the modal

## Testing
- `npm run test:e2e` *(fails: `playwright: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68789421c148832d93db46e2387f7054