### PR TITLE
Add Playwright packages to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.53.2",
+        "playwright": "^1.53.2",
         "@types/node": "^24.0.8"
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/vanntoru/schedule-app#readme",
   "devDependencies": {
     "@playwright/test": "^1.53.2",
+    "playwright": "^1.53.2",
     "@types/node": "^24.0.8"
   }
 }


### PR DESCRIPTION
## Summary
- add `playwright` to package-lock to keep it in sync with `package.json`

## Testing
- `pre-commit run --files package.json package-lock.json` *(fails: command not found)*
- `npm install` *(fails: 403 Forbidden)*
- `npx playwright install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68789f994280832da4a10205600ff510