### PR TITLE
Add Playwright dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,11 @@ pytest -q
 
 ## End-to-End Tests
 
-Playwright is listed under `devDependencies` and must be installed with `npm install` before running the browser tests.
+Playwright is listed under `devDependencies` and must be installed with `npm install`. After installation, run `npx playwright install` to download the browser binaries before running the browser tests.
 
 ```bash
 npm install
+npx playwright install
 npm run test:e2e
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.53.2",
-        "@types/node": "^24.0.8"
+        "@types/node": "^24.0.8",
+        "playwright": "^1.53.2"
       }
     },
     "node_modules/@playwright/test": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/vanntoru/schedule-app#readme",
   "devDependencies": {
     "@playwright/test": "^1.53.2",
-    "@types/node": "^24.0.8"
+    "@types/node": "^24.0.8",
+    "playwright": "^1.53.2"
   }
 }


### PR DESCRIPTION
## Summary
- add `playwright` dev dependency to align with `@playwright/test`
- document `npx playwright install` step in the README

## Testing
- `pytest -q` *(fails: freezegun missing)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6878af78c6a8832d87ff3f2e59a78798