### PR TITLE
Add mockBlocks helper and use in block tests

### DIFF
--- a/tests/e2e/blocks.spec.ts
+++ b/tests/e2e/blocks.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { mockBlocks } from './helpers';
 
 // Ensure importing blocks triggers schedule refresh
 
@@ -8,18 +9,15 @@ test('blocks import regenerates schedule', async ({ page }) => {
     r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
   );
 
-  // Stub blocks import endpoints
-  await page.route('**/api/blocks/import', r => r.fulfill({ status: 204 }));
-  await page.route('**/api/blocks', r => {
-    const data = [
-      {
-        id: 'b1',
-        start_utc: '2025-01-01T00:00:00Z',
-        end_utc: '2025-01-01T00:10:00Z',
-      },
-    ];
-    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(data) });
-  });
+  // Mock blocks API responses
+  const data = [
+    {
+      id: 'b1',
+      start_utc: '2025-01-01T00:00:00Z',
+      end_utc: '2025-01-01T00:10:00Z',
+    },
+  ];
+  await mockBlocks(page, data);
 
   await page.route('**/api/schedule/generate**', r => {
     const body = JSON.stringify({ date: '2025-01-01', slots: new Array(144).fill(0), unplaced: [] });

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -36,3 +36,23 @@ export async function mockGoogleCalendar(
     });
   });
 }
+
+/**
+ * Mock Blocks API requests during Playwright tests.
+ *
+ * Intercepts any network calls to ``/api/blocks`` and related endpoints and
+ * returns ``body``. This handles GET, POST, PUT and DELETE requests without
+ * defining per-method routes.
+ *
+ * @param page  Playwright page instance
+ * @param body  JSON body to return (defaults to empty array)
+ */
+export async function mockBlocks(page: Page, body: any = []): Promise<void> {
+  await page.route('**/api/blocks**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    }),
+  );
+}

--- a/tests/e2e/mobile_block_workflow.spec.ts
+++ b/tests/e2e/mobile_block_workflow.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, devices } from '@playwright/test';
-import { mockGoogleCalendar } from './helpers';
+import { mockGoogleCalendar, mockBlocks } from './helpers';
 
 // Mobile scenario for creating, updating and deleting blocks
 
@@ -50,6 +50,8 @@ test('mobile block workflow via modal form', async ({ page, request }) => {
   for (const b of blocks) {
     await request.delete(`/api/blocks/${b.id}`);
   }
+
+  await mockBlocks(page);
 
   await page.goto('/');
 


### PR DESCRIPTION
## Summary
- add `mockBlocks` helper to mock `/api/blocks` requests
- use the helper in `blocks.spec.ts`
- call the helper in `mobile_block_workflow.spec.ts`

## Testing
- `npm run test:e2e` *(fails: playwright not installed)*
- `npm ci` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_6878e53e5650832dbfd3904d3ec04ac4